### PR TITLE
feat: add architecture tests for DDD layer separation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ concurrency:
 
 # =============================================================================
 # Job Execution Order:
-#   1. lint + static-analysis (parallel)
-#   2. test (requires lint + static-analysis) — PHP matrix, MySQL service
+#   1. lint + static-analysis + arch (parallel)
+#   2. test (requires stage 1) — PHP matrix, MySQL service
 #   3. ci-success (requires all) — final gate
 # =============================================================================
 
@@ -79,6 +79,33 @@ jobs:
       - name: Run Larastan
         run: vendor/bin/phpstan analyse --memory-limit=4G --no-progress
 
+  arch:
+    name: Architecture
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+
+      - name: Cache PHP Dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: php-8.4-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: php-8.4-composer-
+
+      - name: Install PHP Dependencies
+        run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Run Architecture Tests
+        run: vendor/bin/pest --testsuite=Arch
+
   # ===========================================================================
   # STAGE 2: Tests
   # Runs Pest tests against MySQL with PHP version matrix.
@@ -87,7 +114,7 @@ jobs:
   test:
     name: Test (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
-    needs: [lint, static-analysis]
+    needs: [lint, static-analysis, arch]
 
     strategy:
       fail-fast: false
@@ -172,7 +199,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, static-analysis, test]
+    needs: [lint, static-analysis, arch, test]
     if: always()
 
     steps:
@@ -181,6 +208,7 @@ jobs:
           echo "===== Job Results ====="
           echo "Lint:            ${{ needs.lint.result }}"
           echo "Static Analysis: ${{ needs.static-analysis.result }}"
+          echo "Architecture:    ${{ needs.arch.result }}"
           echo "Test:            ${{ needs.test.result }}"
           echo "======================="
 
@@ -191,6 +219,11 @@ jobs:
 
           if [ "${{ needs.static-analysis.result }}" != "success" ]; then
             echo "❌ Static analysis failed"
+            exit 1
+          fi
+
+          if [ "${{ needs.arch.result }}" != "success" ]; then
+            echo "❌ Architecture tests failed"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Laravel Domain Driven
 
-<a href="https://laravel.com/docs/11.x"><img src="https://img.shields.io/badge/Laravel-11-FF2D20.svg?style=flat&logo=laravel" alt="Laravel 11"/></a>
-<a href="https://www.php.net/releases/8.2/en.php"><img src="https://img.shields.io/badge/PHP-8.2-777BB4.svg?style=flat&logo=php" alt="PHP 8.2"/></a>
+<a href="https://laravel.com/docs/12.x"><img src="https://img.shields.io/badge/Laravel-12-FF2D20.svg?style=flat&logo=laravel" alt="Laravel 12"/></a>
+<a href="https://www.php.net/releases/8.4/en.php"><img src="https://img.shields.io/badge/PHP-8.2--8.4-777BB4.svg?style=flat&logo=php" alt="PHP 8.2-8.4"/></a>
 <a href="https://github.com/othercodes/laravel-domain-driven/actions/workflows/test.yml"><img src="https://github.com/othercodes/laravel-domain-driven/actions/workflows/test.yml/badge.svg" alt="Test"/></a>
 
 Welcome to Laravel Domain Driven! This is a Laravel starter designed to help you build applications using Hexagonal
@@ -61,7 +61,8 @@ Using **Laravel Domain Driven** helps you build clean, flexible, and long-lastin
 - **Larastan**: Static analysis tool that helps detect potential issues in your code, improving code quality and
   reducing bugs.
 - **Pest**: A modern testing framework for PHP that makes testing simpler, faster, and more readable, providing a fluent
-  and expressive syntax for writing tests.
+  and expressive syntax for writing tests. Includes **architecture tests** that enforce DDD layer separation and bounded
+  context isolation.
 
 These features are structured in a way that keeps your business logic clean, maintainable, and aligned with modern
 development practices.
@@ -97,6 +98,9 @@ Once installed, start the application with the following commands:
 
 # Run tests to verify everything works
 ./vendor/bin/sail test
+
+# Run only architecture tests (DDD layer and context isolation)
+./vendor/bin/sail pest --testsuite=Arch
 ```
 
 For development with HMR, queue worker, and log tailing:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Arch">
+            <directory>tests/Arch</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Presets
+|--------------------------------------------------------------------------
+*/
+
+arch()->preset()->php();
+arch()->preset()->security();
+
+/*
+|--------------------------------------------------------------------------
+| Domain Layer
+|--------------------------------------------------------------------------
+| The Domain layer is the innermost layer. It must not depend on
+| Application or Infrastructure layers. Only Shared Domain is
+| allowed as a cross-cutting dependency.
+|
+| Known exception: User.php references UserFactory from Infrastructure
+| due to Laravel's HasFactory trait convention. This is a framework
+| coupling that cannot be avoided without breaking Eloquent factories.
+*/
+
+arch('domain does not depend on infrastructure')
+    ->expect('App\*\*\Domain')
+    ->not->toUse('App\*\*\Infrastructure')
+    ->ignoring('App\IdentityAndAccess\Users\Domain\User');
+
+arch('domain does not depend on application')
+    ->expect('App\*\*\Domain')
+    ->not->toUse('App\*\*\Application');
+
+arch('domain contracts are interfaces')
+    ->expect('App\*\*\Domain\Contracts')
+    ->toBeInterfaces();
+
+arch('domain events are final and implement event interface')
+    ->expect('App\*\*\Domain\Events')
+    ->toBeClasses()
+    ->toBeFinal()
+    ->toImplement('App\Shared\Domain\Contracts\ServiceBus\Event');
+
+arch('domain exceptions extend exception')
+    ->expect('App\*\*\Domain\Exceptions')
+    ->toBeClasses()
+    ->toExtend('Exception');
+
+arch('shared domain traits are traits')
+    ->expect('App\Shared\Domain')
+    ->traits()
+    ->toBeTraits();
+
+/*
+|--------------------------------------------------------------------------
+| Application Layer
+|--------------------------------------------------------------------------
+| The Application layer orchestrates use cases. It depends on the
+| Domain layer but must not depend on Infrastructure.
+*/
+
+arch('application does not depend on infrastructure')
+    ->expect('App\*\*\Application')
+    ->not->toUse('App\*\*\Infrastructure');
+
+/*
+|--------------------------------------------------------------------------
+| Infrastructure Layer
+|--------------------------------------------------------------------------
+| The Infrastructure layer provides adapters and implementations.
+| It must not be used directly by the Domain layer.
+*/
+
+arch('controllers have controller suffix')
+    ->expect('App\*\*\Infrastructure\Http\Controllers')
+    ->classes()
+    ->toHaveSuffix('Controller');
+
+arch('middleware has handle method')
+    ->expect('App\Shared\Infrastructure\Http\Middleware')
+    ->toBeClasses()
+    ->toHaveMethod('handle');
+
+/*
+|--------------------------------------------------------------------------
+| Bounded Context Isolation
+|--------------------------------------------------------------------------
+| Each bounded context's Domain and Application layers may only depend
+| on their own context or on Shared Domain. They must never reach into
+| another BC's internals or into Shared Infrastructure.
+|
+| The Shared context is a foundation layer — it must never reference
+| any specific bounded context.
+|
+| When adding a new bounded context, add its isolation rules below.
+*/
+
+arch('identity and access domain only uses own context and shared domain')
+    ->expect('App\IdentityAndAccess\*\Domain')
+    ->not->toUse('App\Shared\Infrastructure')
+    ->not->toUse('App\Shared\Application');
+
+arch('identity and access application only uses own context and shared domain')
+    ->expect('App\IdentityAndAccess\*\Application')
+    ->not->toUse('App\Shared\Infrastructure')
+    ->not->toUse('App\Shared\Application');
+
+// Add new bounded context isolation rules here following the same pattern:
+// arch('{context} domain only uses own context and shared domain')
+//     ->expect('App\{Context}\*\Domain')
+//     ->not->toUse('App\Shared\Infrastructure')
+//     ->not->toUse('App\Shared\Application')
+//     ->not->toUse('App\IdentityAndAccess');
+//
+// arch('{context} application only uses own context and shared domain')
+//     ->expect('App\{Context}\*\Application')
+//     ->not->toUse('App\Shared\Infrastructure')
+//     ->not->toUse('App\Shared\Application')
+//     ->not->toUse('App\IdentityAndAccess');
+
+arch('shared context does not depend on any bounded context')
+    ->expect('App\Shared')
+    ->not->toUse('App\IdentityAndAccess');
+
+/*
+|--------------------------------------------------------------------------
+| Service Providers
+|--------------------------------------------------------------------------
+| Each bounded context wires its own dependencies via a service provider.
+*/
+
+arch('service providers extend base provider')
+    ->expect([
+        'App\IdentityAndAccess\IdentityAndAccessServiceProvider',
+        'App\Shared\SharedServiceProvider',
+    ])
+    ->toExtend('Illuminate\Support\ServiceProvider');
+
+/*
+|--------------------------------------------------------------------------
+| Code Quality
+|--------------------------------------------------------------------------
+*/
+
+arch('no debugging statements')
+    ->expect(['dd', 'dump', 'var_dump', 'ray'])
+    ->not->toBeUsed();
+
+arch('no env calls outside config')
+    ->expect('env')
+    ->not->toBeUsed();


### PR DESCRIPTION
## Summary
- Add Pest architecture tests enforcing hexagonal architecture rules (layer separation, bounded context isolation, code quality presets)
- Register `Arch` test suite in `phpunit.xml`
- Update README badges to Laravel 12 / PHP 8.2-8.4 and document arch test execution

## Test plan
- [x] `sail pest --testsuite=Arch` passes all 17 tests (31 assertions)
- [x] Full test suite `sail test` passes (43 tests)
- [x] CI pipeline passes on PHP 8.2, 8.3, 8.4