### PR TITLE
feat: add version() global helper function

### DIFF
--- a/app/Shared/Application/helpers.php
+++ b/app/Shared/Application/helpers.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Shared\Application\VersionManager;
+use App\Shared\Domain\SemanticVersion;
+
+if (! function_exists('version')) {
+    /**
+     * Get the application semantic version.
+     */
+    function version(): SemanticVersion
+    {
+        return app(VersionManager::class)->version();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
         "pestphp/pest-plugin-faker": "^3.0"
     },
     "autoload": {
+        "files": [
+            "app/Shared/Application/helpers.php"
+        ],
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",


### PR DESCRIPTION
## Summary

Follow-up to #25

Add a `version()` global helper function that returns a `SemanticVersion` value object, providing convenient access to the application version.

### Usage

```php
version()            // SemanticVersion object
version()->major     // "1"
version()->minor     // "2"
version()->patch     // "3"
version()->status    // "beta"
(string) version()   // "1.2.3-beta"
```

### Changes

- `app/Shared/Application/helpers.php` — new helper function
- `composer.json` — register helper via autoload `files` directive

## Test plan

- [x] All 53 tests pass (`sail pest`)
- [x] Laravel Pint: clean
- [x] PHPStan: 0 errors
- [x] All architecture tests pass