### PR TITLE
chore: #39 upgrade Inertia to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "inertiajs/inertia-laravel": "^2.0",
+        "inertiajs/inertia-laravel": "^3.0",
         "laravel/fortify": "^1.30",
         "laravel/framework": "^13.0",
         "laravel/sanctum": "^4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "packages": {
         "": {
             "devDependencies": {
-                "@inertiajs/vue3": "^2.0",
+                "@inertiajs/vue3": "^3.6.1",
                 "@tailwindcss/forms": "^0.5.7",
                 "@tailwindcss/typography": "^0.5.10",
                 "@tailwindcss/vite": "^4.3.1",
@@ -69,30 +69,35 @@
             }
         },
         "node_modules/@inertiajs/core": {
-            "version": "2.3.27",
-            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.3.27.tgz",
-            "integrity": "sha512-UYoKpg/OrpcoLqb9nDmQh+QhQ4dI5B2ZT3LfhSfNWnRUcpMyd/MagcoVeck3zDfEcQscvFMhiZUD/lXpbuixQQ==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-3.6.1.tgz",
+            "integrity": "sha512-h6+qqkKfpcoZvxWENy/F5yyiD00PIm8lK+ruQkt6HGk4d3N0LMS9GeUbWVQ4+TDZzIxP/vQLurPktnYvDhYeew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/lodash-es": "^4.17.12",
-                "axios": "^1.16.0",
-                "laravel-precognition": "^1.0.2",
-                "lodash-es": "^4.18.1",
-                "qs": "^6.15.0"
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "es-toolkit": "^1.33.0",
+                "laravel-precognition": "^2.0.0"
+            },
+            "peerDependencies": {
+                "axios": "^1.15.2"
+            },
+            "peerDependenciesMeta": {
+                "axios": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@inertiajs/vue3": {
-            "version": "2.3.27",
-            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-2.3.27.tgz",
-            "integrity": "sha512-JEqFslFQ8HsgPec0JrIESdIlAYZ5rv7LxlcVF15FF+Olu9y200aDfePskGnCi2PZhYxb8EOA60SJIO9J0I3+hg==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-3.6.1.tgz",
+            "integrity": "sha512-7M76W7uw1DqxWR5O+OV7Yg23yITTDcRxuO7KCdQhI58rp9+OTv2BZId7ePSBmqahYOeXUZbTfZfVoS2O6/hijA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inertiajs/core": "2.3.27",
-                "@types/lodash-es": "^4.17.12",
-                "laravel-precognition": "^1.0.2",
-                "lodash-es": "^4.18.1"
+                "@inertiajs/core": "3.6.1",
+                "es-toolkit": "^1.33.0",
+                "laravel-precognition": "^2.0.0"
             },
             "peerDependencies": {
                 "vue": "^3.0.0"
@@ -701,23 +706,6 @@
                 "vite": "^5.2.0 || ^6 || ^7 || ^8"
             }
         },
-        "node_modules/@types/lodash": {
-            "version": "4.17.25",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
-            "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/lodash-es": {
-            "version": "4.17.12",
-            "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-            "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@vitejs/plugin-vue": {
             "version": "6.0.8",
             "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz",
@@ -913,23 +901,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/call-bound": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/chalk": {
@@ -1191,6 +1162,18 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-toolkit": {
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+            "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+            "dev": true,
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks",
+                "tests/types"
+            ]
+        },
         "node_modules/escalade": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1445,14 +1428,21 @@
             }
         },
         "node_modules/laravel-precognition": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-1.0.2.tgz",
-            "integrity": "sha512-0H08JDdMWONrL/N314fvsO3FATJwGGlFKGkMF3nNmizVFJaWs17816iM+sX7Rp8d5hUjYCx6WLfsehSKfaTxjg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-2.0.0.tgz",
+            "integrity": "sha512-dmA4HGc9m+TsVNsJs9/XQBI8u6j7coilN+qKkBuhuXQzH3HypwS/c5dFQ4UqUGjBbcxIM7zdk91kM/SRZwIvWQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "axios": "^1.4.0",
-                "lodash-es": "^4.17.21"
+                "es-toolkit": "^1.32.0"
+            },
+            "peerDependencies": {
+                "axios": "^1.4.0"
+            },
+            "peerDependenciesMeta": {
+                "axios": {
+                    "optional": true
+                }
             }
         },
         "node_modules/laravel-vite-plugin": {
@@ -1743,13 +1733,6 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/lodash-es": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1829,19 +1812,6 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
-        "node_modules/object-inspect": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1915,23 +1885,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/qs": {
-            "version": "6.15.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "es-define-property": "^1.0.1",
-                "side-channel": "^1.1.1"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1991,82 +1944,6 @@
             "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.4",
-                "side-channel-list": "^1.0.1",
-                "side-channel-map": "^1.0.1",
-                "side-channel-weakmap": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-list": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-map": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-weakmap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3",
-                "side-channel-map": "^1.0.1"
-            },
             "engines": {
                 "node": ">= 0.4"
             },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "dev": "vite"
     },
     "devDependencies": {
-        "@inertiajs/vue3": "^2.0",
+        "@inertiajs/vue3": "^3.6.1",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.10",
         "@tailwindcss/vite": "^4.3.1",


### PR DESCRIPTION
Closes #39

Bumps `inertia-laravel` to 3.3.1 and `@inertiajs/vue3` to 3.6.1. No code changes needed: the Blade directives still work, and the app uses none of the removed APIs.

Note for deploy: v3 renders the initial page into a `<script data-page>` tag instead of a div attribute, so stale compiled views must be cleared (`artisan view:clear`).