### PR TITLE
chore: #41 require PHP 8.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.3', '8.4']
+        php-version: ['8.4']
 
     env:
       APP_ENV: testing

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Laravel Domain Driven
 
-<a href="https://laravel.com/docs/12.x"><img src="https://img.shields.io/badge/Laravel-12-FF2D20.svg?style=flat&logo=laravel" alt="Laravel 12"/></a>
-<a href="https://www.php.net/releases/8.4/en.php"><img src="https://img.shields.io/badge/PHP-8.2--8.4-777BB4.svg?style=flat&logo=php" alt="PHP 8.2-8.4"/></a>
+<a href="https://laravel.com/docs/13.x"><img src="https://img.shields.io/badge/Laravel-13-FF2D20.svg?style=flat&logo=laravel" alt="Laravel 13"/></a>
+<a href="https://www.php.net/releases/8.4/en.php"><img src="https://img.shields.io/badge/PHP-8.4-777BB4.svg?style=flat&logo=php" alt="PHP 8.4"/></a>
 <a href="https://github.com/othercodes/laravel-domain-driven/actions/workflows/test.yml"><img src="https://github.com/othercodes/laravel-domain-driven/actions/workflows/test.yml/badge.svg" alt="Test"/></a>
 
 Welcome to Laravel Domain Driven! This is a Laravel starter designed to help you build applications using Hexagonal

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/fortify": "^1.30",
         "laravel/framework": "^13.0",


### PR DESCRIPTION
Closes #41

Raises the floor to `^8.4` so the resolved tree matches what Sail and production actually run (Symfony 8.1), instead of CI validating a Symfony 7.4 tree that never ships. Drops the 8.3 leg from the matrix and refreshes the stale README badges.