### PR TITLE
chore: #43 enforce the npm lockfile in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
         run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
       - name: Install Node.js Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build Frontend
         run: npm run build


### PR DESCRIPTION
Closes #43

Swaps `npm install` for `npm ci` so the committed `package-lock.json` is actually enforced and drift against `package.json` fails the build.