### PR TITLE
chore: #54 add an APITokens aggregate for Sanctum

### DIFF
--- a/app/IdentityAndAccess/APITokens/Domain/APIToken.php
+++ b/app/IdentityAndAccess/APITokens/Domain/APIToken.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\IdentityAndAccess\APITokens\Domain;
+
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * Class APIToken
+ *
+ * Owns the token table instead of publishing Sanctum's migration, which
+ * declares a `morphs('tokenable')` and would therefore store a bigint that
+ * cannot hold the uuid identifiers this application gives its users.
+ *
+ * Registered via Sanctum::usePersonalAccessTokenModel() in the bounded
+ * context service provider.
+ *
+ * @property string $tokenable_type
+ * @property string $tokenable_id
+ * @property string $name
+ * @property string $token
+ * @property string|null $abilities
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+class APIToken extends PersonalAccessToken
+{
+    protected $table = 'api_tokens';
+}

--- a/app/IdentityAndAccess/APITokens/Infrastructure/Persistence/Migrations/0000_00_00_000002_create_api_tokens_table.php
+++ b/app/IdentityAndAccess/APITokens/Infrastructure/Persistence/Migrations/0000_00_00_000002_create_api_tokens_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/*
+ * Mirrors Sanctum's personal_access_tokens table, with uuidMorphs instead of
+ * morphs so that tokenable_id can hold the uuid identifiers used by users.
+ * Sanctum's own migration is never published; see APIToken.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('api_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->uuidMorphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('api_tokens');
+    }
+};

--- a/app/IdentityAndAccess/IdentityAndAccessServiceProvider.php
+++ b/app/IdentityAndAccess/IdentityAndAccessServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\IdentityAndAccess;
 
+use App\IdentityAndAccess\APITokens\Domain\APIToken;
 use App\IdentityAndAccess\Users\Application\CreateUser;
 use App\IdentityAndAccess\Users\Application\EventHandlers\SendUserEmailVerification;
 use App\IdentityAndAccess\Users\Application\ResetUserPassword;
@@ -17,6 +18,7 @@ use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Laravel\Fortify\Fortify;
+use Laravel\Sanctum\Sanctum;
 
 /**
  * Class IdentityAndAccessServiceProvider
@@ -35,11 +37,16 @@ class IdentityAndAccessServiceProvider extends BoundedContextServiceProvider
 
     protected array $migrations = [
         __DIR__.'/Users/Infrastructure/Persistence/Migrations',
+        __DIR__.'/APITokens/Infrastructure/Persistence/Migrations',
     ];
 
     public function boot(): void
     {
         parent::boot();
+
+        // Sanctum's own model points at personal_access_tokens, whose
+        // tokenable_id is a bigint and cannot hold a user uuid.
+        Sanctum::usePersonalAccessTokenModel(APIToken::class);
 
         $this->bootFortify();
     }

--- a/app/IdentityAndAccess/Users/Domain/User.php
+++ b/app/IdentityAndAccess/Users/Domain/User.php
@@ -17,6 +17,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Fortify\TwoFactorAuthenticatable;
+use Laravel\Sanctum\HasApiTokens;
 
 /**
  * Class User
@@ -35,6 +36,7 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
  */
 class User extends Authenticatable implements MustVerifyEmail
 {
+    use HasApiTokens;
     use HasDomainEvents;
     use HasFactory;
     use HasProfilePhoto;

--- a/tests/Feature/APITokenTest.php
+++ b/tests/Feature/APITokenTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\IdentityAndAccess\APITokens\Domain\APIToken;
+use App\IdentityAndAccess\Users\Domain\User;
+use Laravel\Sanctum\Sanctum;
+
+test('sanctum issues tokens through the APIToken model', function () {
+    $user = User::factory()->create();
+
+    $token = $user->createToken('test-token')->accessToken;
+
+    expect($token)->toBeInstanceOf(APIToken::class)
+        ->and($token->getTable())->toBe('api_tokens')
+        ->and($token->tokenable_id)->toBe($user->id);
+});
+
+test('a uuid identified user can be authenticated by token', function () {
+    $user = User::factory()->create();
+
+    $this->withHeader('Authorization', 'Bearer '.$user->createToken('test-token')->plainTextToken)
+        ->getJson('/api/user')
+        ->assertOk()
+        ->assertJsonPath('id', $user->id);
+});
+
+test('the api rejects unauthenticated requests', function () {
+    $this->getJson('/api/user')->assertUnauthorized();
+});
+
+test('sanctum is not using its own personal access token model', function () {
+    expect(Sanctum::personalAccessTokenModel())->toBe(APIToken::class);
+});


### PR DESCRIPTION
Closes #54

The starter uses Sanctum as a session guard, so the tokens table never existed and `User` did not even have `HasApiTokens`. Publishing Sanctum's own migration would bring `morphs('tokenable')` — a bigint that cannot hold a user uuid.

So the context owns the table: an `api_tokens` migration using `uuidMorphs`, an `APIToken extends PersonalAccessToken` pointing at it, and `Sanctum::usePersonalAccessTokenModel()` in the provider.

Verified end to end over HTTP before writing the tests: 401 without a token, and the user's uuid returned with one. The three tests that matter were checked to fail when the model registration is removed.