### PR TITLE
fix: #57 route profile updates through the User aggregate

### DIFF
--- a/app/IdentityAndAccess/Users/Application/UpdateUserProfileInformation.php
+++ b/app/IdentityAndAccess/Users/Application/UpdateUserProfileInformation.php
@@ -2,13 +2,26 @@
 
 namespace App\IdentityAndAccess\Users\Application;
 
+use App\IdentityAndAccess\Users\Domain\Contracts\UserRepository;
 use App\IdentityAndAccess\Users\Domain\User;
+use ComplexHeart\Domain\Contracts\Events\EventBus;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
-class UpdateUserProfileInformation implements UpdatesUserProfileInformation
+/**
+ * Class UpdateUserProfileInformation
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+final readonly class UpdateUserProfileInformation implements UpdatesUserProfileInformation
 {
+    public function __construct(
+        private UserRepository $repository,
+        private EventBus $eventBus,
+    ) {}
+
     /**
      * Validate and update the given user's profile information.
      *
@@ -26,29 +39,15 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             $user->updateProfilePhoto($input['photo']);
         }
 
-        if ($input['email'] !== $user->email) {
-            $this->updateVerifiedUser($user, $input);
-        } else {
-            $user->forceFill([
-                'name' => $input['name'],
-                'email' => $input['email'],
-            ])->save();
-        }
-    }
+        // The aggregate decides what changed and records the matching events;
+        // resetting email_verified_at and sending the verification notice are
+        // consequences of UserEmailUpdated, not of this use case.
+        DB::transaction(function () use ($user, $input): void {
+            $this->repository->save(
+                $user->updateName($input['name'])->updateEmail($input['email'])
+            );
 
-    /**
-     * Update the given verified user's profile information.
-     *
-     * @param  array<string, string>  $input
-     */
-    protected function updateVerifiedUser(User $user, array $input): void
-    {
-        $user->forceFill([
-            'name' => $input['name'],
-            'email' => $input['email'],
-            'email_verified_at' => null,
-        ])->save();
-
-        $user->sendEmailVerificationNotification();
+            $user->publishDomainEvents($this->eventBus);
+        });
     }
 }

--- a/tests/Feature/ProfileInformationTest.php
+++ b/tests/Feature/ProfileInformationTest.php
@@ -1,6 +1,11 @@
 <?php
 
+use App\IdentityAndAccess\Users\Domain\Events\UserEmailUpdated;
+use App\IdentityAndAccess\Users\Domain\Events\UserNameUpdated;
 use App\IdentityAndAccess\Users\Domain\User;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
 
 test('profile information can be updated', function () {
     $this->actingAs($user = User::factory()->create());
@@ -13,4 +18,65 @@ test('profile information can be updated', function () {
     expect($user->fresh())
         ->name->toEqual('Test Name')
         ->email->toEqual('test@example.com');
+});
+
+test('changing the name publishes UserNameUpdated', function () {
+    Event::fake([UserNameUpdated::class, UserEmailUpdated::class]);
+
+    $this->actingAs($user = User::factory()->create());
+
+    $this->put('/user/profile-information', [
+        'name' => 'Test Name',
+        'email' => $user->email,
+    ]);
+
+    Event::assertDispatched(
+        UserNameUpdated::class,
+        fn (UserNameUpdated $event): bool => $event->user === $user->id
+    );
+    Event::assertNotDispatched(UserEmailUpdated::class);
+});
+
+test('changing the email publishes UserEmailUpdated and unverifies the address', function () {
+    Event::fake([UserEmailUpdated::class]);
+
+    $this->actingAs($user = User::factory()->create());
+
+    $this->put('/user/profile-information', [
+        'name' => $user->name,
+        'email' => 'new@example.com',
+    ]);
+
+    Event::assertDispatched(
+        UserEmailUpdated::class,
+        fn (UserEmailUpdated $event): bool => $event->user === $user->id
+    );
+    expect($user->fresh()->email_verified_at)->toBeNull();
+});
+
+test('the verification notice is sent by the UserEmailUpdated listener', function () {
+    Notification::fake();
+
+    $this->actingAs($user = User::factory()->create());
+
+    $this->put('/user/profile-information', [
+        'name' => $user->name,
+        'email' => 'new@example.com',
+    ]);
+
+    Notification::assertSentTo($user->fresh(), VerifyEmail::class);
+});
+
+test('an unchanged profile publishes nothing', function () {
+    Event::fake([UserNameUpdated::class, UserEmailUpdated::class]);
+
+    $this->actingAs($user = User::factory()->create());
+
+    $this->put('/user/profile-information', [
+        'name' => $user->name,
+        'email' => $user->email,
+    ]);
+
+    Event::assertNotDispatched(UserNameUpdated::class);
+    Event::assertNotDispatched(UserEmailUpdated::class);
 });


### PR DESCRIPTION
Closes #57

`UpdateUserProfileInformation` now calls `updateName()` / `updateEmail()` and publishes what the aggregate recorded, instead of writing with `forceFill()`. Resetting `email_verified_at` and sending the verification notice become consequences of `UserEmailUpdated`, so the `SendUserEmailVerification` listener wired in the provider finally runs and the inline call disappears.

Note the verification mail is now queued, since that listener is `ShouldQueue` — `composer dev` already runs a worker and tests use the sync driver.

The pre-existing test stayed green against the old code while the three new ones failed, which is why this went unnoticed.