### PR TITLE
feat: #59 move routes into their bounded contexts

### DIFF
--- a/app/IdentityAndAccess/IdentityAndAccessServiceProvider.php
+++ b/app/IdentityAndAccess/IdentityAndAccessServiceProvider.php
@@ -40,6 +40,11 @@ class IdentityAndAccessServiceProvider extends BoundedContextServiceProvider
         __DIR__.'/APITokens/Infrastructure/Persistence/Migrations',
     ];
 
+    protected array $routes = [
+        'web' => [__DIR__.'/Shared/Infrastructure/Http/Routes/web.php'],
+        'api' => [__DIR__.'/Shared/Infrastructure/Http/Routes/api.php'],
+    ];
+
     public function boot(): void
     {
         parent::boot();

--- a/app/IdentityAndAccess/Shared/Infrastructure/Http/Routes/api.php
+++ b/app/IdentityAndAccess/Shared/Infrastructure/Http/Routes/api.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+// The api middleware group is applied by the service provider, but the URI
+// prefix is not — BoundedContextServiceProvider::bootRoutes() only groups by
+// middleware, so each context declares its own prefix.
+Route::prefix('api')->middleware('auth:sanctum')->group(function () {
+    Route::get('/user', fn (Request $request) => $request->user())->name('user');
+});

--- a/app/IdentityAndAccess/Shared/Infrastructure/Http/Routes/web.php
+++ b/app/IdentityAndAccess/Shared/Infrastructure/Http/Routes/web.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\IdentityAndAccess\Users\Infrastructure\Http\Controllers\DeleteUserController;
+use App\IdentityAndAccess\Users\Infrastructure\Http\Controllers\OtherBrowserSessionsController;
+use App\IdentityAndAccess\Users\Infrastructure\Http\Controllers\UserProfileController;
+use App\IdentityAndAccess\Users\Infrastructure\Http\Controllers\UserProfilePhotoController;
+use App\Shared\Infrastructure\Http\Middleware\AuthenticateSession;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['auth:sanctum', AuthenticateSession::class])->group(function () {
+    Route::get('/user/profile', [UserProfileController::class, 'show'])->name('profile.show');
+    Route::delete('/user/other-browser-sessions', [OtherBrowserSessionsController::class, 'destroy'])->name('other-browser-sessions.destroy');
+    Route::delete('/user/profile-photo', [UserProfilePhotoController::class, 'destroy'])->name('current-user-photo.destroy');
+    Route::delete('/user', [DeleteUserController::class, 'destroy'])->name('current-user.destroy');
+});

--- a/app/Shared/Infrastructure/Http/Routes/web.php
+++ b/app/Shared/Infrastructure/Http/Routes/web.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Shared\Infrastructure\Http\Controllers\PrivacyPolicyController;
+use App\Shared\Infrastructure\Http\Controllers\TermsOfServiceController;
+use App\Shared\Infrastructure\Http\Middleware\AuthenticateSession;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+
+Route::get('/', fn () => Inertia::render('Welcome', [
+    'canLogin' => Route::has('login'),
+    'canRegister' => Route::has('register'),
+    'laravelVersion' => Application::VERSION,
+    'phpVersion' => PHP_VERSION,
+]));
+
+Route::get('/terms-of-service', [TermsOfServiceController::class, 'show'])->name('terms.show');
+Route::get('/privacy-policy', [PrivacyPolicyController::class, 'show'])->name('policy.show');
+
+Route::middleware(['auth:sanctum', AuthenticateSession::class, 'verified'])->group(function () {
+    Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->name('dashboard');
+});

--- a/app/Shared/SharedServiceProvider.php
+++ b/app/Shared/SharedServiceProvider.php
@@ -27,6 +27,10 @@ class SharedServiceProvider extends BoundedContextServiceProvider
         __DIR__.'/Infrastructure/Persistence/Migrations',
     ];
 
+    protected array $routes = [
+        'web' => [__DIR__.'/Infrastructure/Http/Routes/web.php'],
+    ];
+
     public function boot(): void
     {
         parent::boot();

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,15 @@
 <?php
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
-
-Route::middleware(['auth:sanctum'])->group(function () {
-    Route::get('/user', fn (Request $request) => $request->user())->name('user');
-});
+/*
+|--------------------------------------------------------------------------
+| API Routes
+|--------------------------------------------------------------------------
+|
+| Intentionally empty. Each bounded context publishes its own API routes
+| through the $routes array on its service provider, at
+| app/<Context>/Shared/Infrastructure/Http/Routes/api.php.
+|
+| bootRoutes() applies the api middleware group but not the URI prefix, so
+| those files declare Route::prefix('api') themselves.
+|
+*/

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,39 +1,16 @@
 <?php
 
-use App\IdentityAndAccess\Users\Infrastructure\Http\Controllers\DeleteUserController;
-use App\IdentityAndAccess\Users\Infrastructure\Http\Controllers\OtherBrowserSessionsController;
-use App\IdentityAndAccess\Users\Infrastructure\Http\Controllers\UserProfileController;
-use App\IdentityAndAccess\Users\Infrastructure\Http\Controllers\UserProfilePhotoController;
-use App\Shared\Infrastructure\Http\Controllers\PrivacyPolicyController;
-use App\Shared\Infrastructure\Http\Controllers\TermsOfServiceController;
-use App\Shared\Infrastructure\Http\Middleware\AuthenticateSession;
-use Illuminate\Foundation\Application;
-use Illuminate\Support\Facades\Route;
-use Inertia\Inertia;
-
-Route::get('/', fn () => Inertia::render('Welcome', [
-    'canLogin' => Route::has('login'),
-    'canRegister' => Route::has('register'),
-    'laravelVersion' => Application::VERSION,
-    'phpVersion' => PHP_VERSION,
-]));
-
-Route::middleware(['auth:sanctum', AuthenticateSession::class, 'verified'])->group(function () {
-    Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->name('dashboard');
-});
-
-Route::group(['domain' => null, 'prefix' => null], function () {
-    Route::group(['middleware' => ['web']], function () {
-        Route::get('/terms-of-service', [TermsOfServiceController::class, 'show'])->name('terms.show');
-        Route::get('/privacy-policy', [PrivacyPolicyController::class, 'show'])->name('policy.show');
-
-        Route::group(['middleware' => ['auth:sanctum', AuthenticateSession::class]], function () {
-            Route::get('/user/profile', [UserProfileController::class, 'show'])->name('profile.show');
-            Route::delete('/user/other-browser-sessions', [OtherBrowserSessionsController::class, 'destroy'])->name('other-browser-sessions.destroy');
-            Route::delete('/user/profile-photo', [UserProfilePhotoController::class, 'destroy'])->name('current-user-photo.destroy');
-            Route::delete('/user', [DeleteUserController::class, 'destroy'])->name('current-user.destroy');
-
-            Route::group(['middleware' => 'verified'], function () {});
-        });
-    });
-});
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Intentionally empty. Each bounded context publishes its own web routes
+| through the $routes array on its service provider, which is wired by
+| ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider.
+|
+| They live at app/<Context>/Shared/Infrastructure/Http/Routes/web.php,
+| and at app/Shared/Infrastructure/Http/Routes/web.php for the routes the
+| whole application shares.
+|
+*/


### PR DESCRIPTION
Closes #59

Each context now publishes its own routes through the `$routes` array on its provider: `app/Shared/.../Routes/web.php` for what the whole app shares, and `app/IdentityAndAccess/Shared/.../Routes/{web,api}.php` for identity. The central files stay as documented placeholders.

The api file declares `Route::prefix('api')` itself, because `bootRoutes()` applies the middleware group but not the prefix.

Verified with `route:list -v`: the same 9 routes with the same middleware stacks as before.