### PR TITLE
feat: #24 add the ldd:make:aggregate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ resolvable at all. Everything else is opt in, because real aggregates rarely nee
 |---|---|
 | `--migration` | A migration, and its path in the provider's `$migrations` |
 | `--factory` | A model factory, routed through the aggregate's `new()` |
-| `--events` | A `Created` domain event, recorded by `new()` |
+| `--events` | A `Created` domain event, recorded by `new()` and published by you |
 | `--requests` | A form request |
 | `--web` | An Inertia controller, rendering through `InertiaController` |
 | `--api` | An API controller |
@@ -149,6 +149,10 @@ resolvable at all. Everything else is opt in, because real aggregates rarely nee
 
 The table name defaults to the pluralised aggregate. Two contexts may each own an `Invoice`, but
 only one can create the `invoices` table, so `--table=billing_invoices` renames it for the second.
+
+An aggregate records its domain events; publishing them belongs to a use case, which injects
+`EventBus` and calls `publishDomainEvents()` inside the transaction that saved the aggregate. Until
+one exists the events go nowhere, so `--events` prints the two lines that close the loop.
 
 Both commands only ever add. Run one again with a flag you skipped and it writes what is missing,
 leaves every file already on disk alone — your migration may have been applied, and the provider

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ resolvable at all. Everything else is opt in, because real aggregates rarely nee
 | `--api` | An API controller |
 | `--all` | All of the above |
 
+The table name defaults to the pluralised aggregate. Two contexts may each own an `Invoice`, but
+only one can create the `invoices` table, so `--table=billing_invoices` renames it for the second.
+
 ## 📁 Structure
 
 The structure of the `app/` directory in **Laravel Domain Driven** starter package is organized around different

--- a/README.md
+++ b/README.md
@@ -127,7 +127,24 @@ need and the provider will declare them for you:
 ```
 
 No layer directories are created. A context earns its `Domain`, `Application` and `Infrastructure`
-one aggregate at a time — in real projects plenty of aggregates never need all three.
+one aggregate at a time:
+
+```bash
+./vendor/bin/sail artisan ldd:make:aggregate Billing Invoice
+```
+
+That writes the aggregate root, its repository contract and Eloquent implementation, and its
+exceptions — then binds the repository in the context's service provider, which is what makes it
+resolvable at all. Everything else is opt in, because real aggregates rarely need every layer:
+
+| Flag | Adds |
+|---|---|
+| `--migration` | A migration, and its path in the provider's `$migrations` |
+| `--factory` | A model factory, routed through the aggregate's `new()` |
+| `--events` | A `Created` domain event, recorded by `new()` |
+| `--requests` | A form request |
+| `--api` | An API controller |
+| `--all` | All of the above |
 
 ## 📁 Structure
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ resolvable at all. Everything else is opt in, because real aggregates rarely nee
 | `--factory` | A model factory, routed through the aggregate's `new()` |
 | `--events` | A `Created` domain event, recorded by `new()` |
 | `--requests` | A form request |
+| `--web` | An Inertia controller, rendering through `InertiaController` |
 | `--api` | An API controller |
 | `--all` | All of the above |
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ resolvable at all. Everything else is opt in, because real aggregates rarely nee
 The table name defaults to the pluralised aggregate. Two contexts may each own an `Invoice`, but
 only one can create the `invoices` table, so `--table=billing_invoices` renames it for the second.
 
+Both commands only ever add. Run one again with a flag you skipped and it writes what is missing,
+leaves every file already on disk alone — your migration may have been applied, and the provider
+carries wiring no stub knows about — and prints the lines to add by hand.
+
 ## 📁 Structure
 
 The structure of the `app/` directory in **Laravel Domain Driven** starter package is organized around different

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -131,6 +131,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $this->components->info("Aggregate [{$this->aggregate}] ".($modelExisted ? 'updated' : 'created')." in [{$this->context}].");
 
         $this->printModelHints($path, $modelExisted);
+        $this->printEventHints($path);
         $this->printRouteHints();
 
         // The files exist but the context does not know about them, so a
@@ -174,6 +175,37 @@ final class MakeAggregateCommand extends ScaffoldCommand
         foreach ($lines as $line) {
             $this->line("  <fg=gray>{$line}</>");
         }
+    }
+
+    /**
+     * A recorded domain event does nothing until something publishes it, and
+     * in this application that is the job of a use case: the repository only
+     * persists. Nothing generated here closes that loop, and an event that is
+     * never published fails the way everything else in these commands is
+     * built to prevent — silently.
+     */
+    private function printEventHints(string $path): void
+    {
+        if (! $this->wants('events')) {
+            return;
+        }
+
+        // What the aggregate's application layer already does decides this.
+        $application = "{$path}/Application";
+
+        if ($this->files->isDirectory($application)) {
+            foreach ($this->files->allFiles($application) as $file) {
+                if (str_contains($file->getContents(), 'publishDomainEvents')) {
+                    return;
+                }
+            }
+        }
+
+        $this->newLine();
+        $this->line("  <fg=yellow>Nothing publishes {$this->aggregate}Created. Add a use case in {$this->plural}/Application that does:</>");
+        $this->line("  <fg=gray>\${$this->variable} = \$this->repository->save({$this->aggregate}::new(\$input));</>");
+        $this->line("  <fg=gray>\${$this->variable}->publishDomainEvents(\$this->eventBus);  // ComplexHeart\\Domain\\Contracts\\Events\\EventBus</>");
+        $this->line('  <fg=gray>// both inside DB::transaction, so a failing listener cannot leave the aggregate persisted</>');
     }
 
     /**

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -137,14 +137,24 @@ final class MakeAggregateCommand extends ScaffoldCommand
         // Web and api must differ in both URI and name. RouteCollection keys
         // routes by method and URI, so reusing the URI replaces the web route
         // outright instead of adding a second one; and a route name is global,
-        // so sharing that resolves route() to whichever came first. The api
-        // file gets no URI prefix of its own, hence carrying it in the path.
-        $routes = [
-            'web' => ['uri' => "/{$slug}", 'name' => "{$slug}.show"],
-            'api' => ['uri' => "/api/{$slug}", 'name' => "api.{$slug}.show"],
+        // so sharing that resolves route() to whichever came first.
+        //
+        // The api URI is kept distinct by the prefix group the context's api
+        // file declares, which is the convention the rest of the application
+        // follows: bootRoutes() applies the middleware group but no prefix.
+        $route = fn (string $name): string => "Route::get('/{$slug}/{id}', [{$this->aggregate}Controller::class, 'show'])->name('{$name}');";
+
+        $snippets = [
+            'web' => [$route("{$slug}.show")],
+            'api' => [
+                "Route::prefix('api')->group(function () {",
+                '    '.$route("api.{$slug}.show"),
+                '});',
+                "// the {$this->aggregate}Controller here is the one under Http\\Controllers\\API",
+            ],
         ];
 
-        foreach ($routes as $kind => $route) {
+        foreach ($snippets as $kind => $lines) {
             if (! $this->wants($kind)) {
                 continue;
             }
@@ -153,10 +163,9 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
             $this->newLine();
             $this->line("  Add to <options=bold>{$this->relative($file)}</>:");
-            $this->line("  <fg=gray>Route::get('{$route['uri']}/{id}', [{$this->aggregate}Controller::class, 'show'])->name('{$route['name']}');</>");
 
-            if ($kind === 'api') {
-                $this->line("  <fg=gray>// importing the {$this->aggregate}Controller under Http\\Controllers\\API</>");
+            foreach ($lines as $line) {
+                $this->line("  <fg=gray>{$line}</>");
             }
 
             // Both commands make route files opt in, so this one may well not

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -63,6 +63,16 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $this->variable = Str::camel($this->aggregate);
         $this->table = (string) ($this->option('table') ?: Str::snake($this->plural));
 
+        // The table name is interpolated into the model's $table property and
+        // into Schema::create(), so a quote or a space in it produces two
+        // files that do not parse — and the migrations path is registered as a
+        // directory, which takes `migrate` down with it.
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $this->table) !== 1) {
+            $this->components->error("The table name must be a valid identifier, [{$this->table}] is not.");
+
+            return self::FAILURE;
+        }
+
         if ($this->context === self::SHARED_CONTEXT) {
             $this->components->error('[Shared] is the foundation layer, not a bounded context that can own aggregates.');
 
@@ -91,7 +101,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
         if ($this->wants('migration') && ($owner = $this->tableOwnedElsewhere()) !== null) {
             $this->components->error("Table [{$this->table}] already has a create migration in [{$owner}].");
             $this->components->bulletList([
-                "Pass a different name with: --table={$this->context}_{$this->table}",
+                'Pass a different name with: --table='.Str::snake($this->context)."_{$this->table}",
             ]);
 
             return self::FAILURE;
@@ -121,20 +131,39 @@ final class MakeAggregateCommand extends ScaffoldCommand
      */
     private function printRouteHints(): void
     {
-        $routes = base_path("app/{$this->context}/Shared/Infrastructure/Http/Routes");
+        $dir = app_path("{$this->context}/Shared/Infrastructure/Http/Routes");
         $slug = Str::kebab($this->plural);
+
+        // A route name is global, so web and api cannot share one: Laravel
+        // keeps both routes but resolves route() to whichever was registered
+        // first, leaving the other unreachable by name.
+        foreach (['web' => '', 'api' => 'api.'] as $kind => $prefix) {
+            if (! $this->wants($kind)) {
+                continue;
+            }
+
+            $file = "{$dir}/{$kind}.php";
+
+            $this->newLine();
+            $this->line("  Add to <options=bold>{$this->relative($file)}</>:");
+            $this->line("  <fg=gray>Route::get('/{$slug}/{id}', [{$this->aggregate}Controller::class, 'show'])->name('{$prefix}{$slug}.show');</>");
+
+            if ($kind === 'api') {
+                $this->line("  <fg=gray>// importing the {$this->aggregate}Controller under Http\\Controllers\\API</>");
+            }
+
+            // Both commands make route files opt in, so this one may well not
+            // exist. Creating it is not enough either: a route file the
+            // provider does not declare is never loaded, and the only symptom
+            // is a 404.
+            if (! $this->files->exists($file)) {
+                $this->line("  <fg=yellow>That file does not exist yet: create it and declare it in {$this->context}ServiceProvider::\$routes.</>");
+            }
+        }
 
         if ($this->wants('web')) {
             $this->newLine();
-            $this->line("  Add to <options=bold>{$this->relative($routes)}/web.php</>:");
-            $this->line("  <fg=gray>Route::get('/{$slug}/{id}', [{$this->aggregate}Controller::class, 'show'])->name('{$slug}.show');</>");
-            $this->line("  and create the page at <options=bold>resources/templates/tailwindcss/js/Pages/{$this->plural}/Show.vue</>");
-        }
-
-        if ($this->wants('api')) {
-            $this->newLine();
-            $this->line("  Add to <options=bold>{$this->relative($routes)}/api.php</>:");
-            $this->line("  <fg=gray>Route::get('/{$slug}/{id}', [{$this->aggregate}Controller::class, 'show'])->name('{$slug}.show');</>");
+            $this->line("  Create the page at <options=bold>resources/templates/tailwindcss/js/Pages/{$this->plural}/Show.vue</>");
         }
     }
 
@@ -306,58 +335,9 @@ final class MakeAggregateCommand extends ScaffoldCommand
         return true;
     }
 
-    /**
-     * Appends an entry to a declared property array, whatever shape it is
-     * currently written in.
-     *
-     * Returns null when the property cannot be found, so the caller can
-     * report a failure rather than silently rewriting the file unchanged.
-     */
     private function appendToArray(string $contents, string $property, string $entry): ?string
     {
-        $empty = "array \${$property} = [];";
-
-        if (str_contains($contents, $empty)) {
-            return str_replace($empty, "array \${$property} = [\n{$entry}\n    ];", $contents);
-        }
-
-        // Already populated and spread over several lines.
-        $multiline = preg_replace_callback(
-            '/(array \$'.preg_quote($property, '/').' = \[\n)(.*?)(^    \];)/ms',
-            fn (array $m): string => $m[1].$m[2].$entry."\n".$m[3],
-            $contents,
-            1,
-            $count
-        );
-
-        if ($count > 0) {
-            return $multiline;
-        }
-
-        // Declared inline, e.g. `public array $bindings = [Foo::class => Bar::class];`
-        $inline = preg_replace_callback(
-            '/array \$'.preg_quote($property, '/').' = \[(.*?)\];/s',
-            function (array $m) use ($property, $entry): string {
-                $body = $m[1];
-
-                // A body that is only whitespace or comments holds no elements:
-                // emitting it as one produces `[,` and a parse error.
-                $hasElements = trim((string) preg_replace('#/\*.*?\*/|//[^\n]*#s', '', $body)) !== '';
-
-                if (! $hasElements) {
-                    return "array \${$property} = [".rtrim($body)."\n{$entry}\n    ];";
-                }
-
-                $existing = rtrim(trim($body), ',');
-
-                return "array \${$property} = [\n        {$existing},\n{$entry}\n    ];";
-            },
-            $contents,
-            1,
-            $count
-        );
-
-        return $count > 0 ? $inline : null;
+        return $this->appendToList($contents, "array \${$property} = [", $entry);
     }
 
     /**

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -27,6 +27,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
         {--factory : Add a model factory}
         {--events : Add a Created domain event and record it}
         {--requests : Add a form request}
+        {--web : Add an Inertia controller}
         {--api : Add an API controller}
         {--all : Everything above}
         {--force : Overwrite files that already exist}';
@@ -75,13 +76,33 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $this->newLine();
         $this->components->info("Aggregate [{$this->aggregate}] created in [{$this->context}].");
 
-        if ($this->wants('api')) {
-            $this->components->bulletList([
-                "Register the controller in app/{$this->context}/Shared/Infrastructure/Http/Routes/api.php",
-            ]);
-        }
+        $this->printRouteHints();
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Controllers are generated, but neither the route nor the Vue page is:
+     * routes live in a file the developer owns, and the page lives outside
+     * app/ under a path that vite.config.js decides. So they get printed.
+     */
+    private function printRouteHints(): void
+    {
+        $routes = base_path("app/{$this->context}/Shared/Infrastructure/Http/Routes");
+        $slug = Str::kebab($this->plural);
+
+        if ($this->wants('web')) {
+            $this->newLine();
+            $this->line("  Add to <options=bold>{$this->relative($routes)}/web.php</>:");
+            $this->line("  <fg=gray>Route::get('/{$slug}', [{$this->aggregate}Controller::class, 'index'])->name('{$slug}.index');</>");
+            $this->line("  and create the page at <options=bold>resources/templates/tailwindcss/js/Pages/{$this->plural}/Index.vue</>");
+        }
+
+        if ($this->wants('api')) {
+            $this->newLine();
+            $this->line("  Add to <options=bold>{$this->relative($routes)}/api.php</>:");
+            $this->line("  <fg=gray>Route::get('/{$slug}', [{$this->aggregate}Controller::class, 'index'])->name('{$slug}.index');</>");
+        }
     }
 
     private function wants(string $option): bool
@@ -145,6 +166,10 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
         if ($this->wants('requests')) {
             $this->put("{$path}/Infrastructure/Http/Requests/Store{$this->aggregate}Request.php", $this->stub('aggregate.request', $this->replacements()));
+        }
+
+        if ($this->wants('web')) {
+            $this->put("{$path}/Infrastructure/Http/Controllers/{$this->aggregate}Controller.php", $this->stub('aggregate.web-controller', $this->replacements()));
         }
 
         if ($this->wants('api')) {
@@ -221,6 +246,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
             '{{ aggregate }}' => $this->aggregate,
             '{{ plural }}' => $this->plural,
             '{{ variable }}' => $this->variable,
+            '{{ pluralVariable }}' => Str::camel($this->plural),
             '{{ table }}' => $this->table,
             '{{ author }}' => config('app.scaffold_author', 'Unay Santisteban <usantisteban@othercode.io>'),
         ], $extra);

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -96,6 +96,21 @@ final class MakeAggregateCommand extends ScaffoldCommand
         // the migration may already have been applied.
         $modelExisted = $this->files->exists("{$path}/Domain/{$this->aggregate}.php");
 
+        // The model is never rewritten, so a migration for a table it does not
+        // declare creates one nothing reads, next to the one it does use.
+        if ($this->wants('migration') && $modelExisted) {
+            $declared = $this->tableDeclaredIn("{$path}/Domain/{$this->aggregate}.php");
+
+            if ($declared !== null && $declared !== $this->table) {
+                $this->components->error("[{$this->aggregate}] declares table [{$declared}], not [{$this->table}].");
+                $this->components->bulletList([
+                    "Pass --table={$declared}, or change the model's \$table by hand first.",
+                ]);
+
+                return self::FAILURE;
+            }
+        }
+
         if ($this->wants('migration') && ($owner = $this->tableOwnedElsewhere()) !== null) {
             $this->components->error("Table [{$this->table}] already has a create migration in [{$owner}].");
             $this->components->bulletList([
@@ -115,7 +130,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $this->newLine();
         $this->components->info("Aggregate [{$this->aggregate}] ".($modelExisted ? 'updated' : 'created')." in [{$this->context}].");
 
-        $this->printModelHints($modelExisted);
+        $this->printModelHints($path, $modelExisted);
         $this->printRouteHints();
 
         // The files exist but the context does not know about them, so a
@@ -128,20 +143,24 @@ final class MakeAggregateCommand extends ScaffoldCommand
      * rewritten once it exists. Adding either option later costs a line or
      * two by hand, which is the price of never losing what the model grew.
      */
-    private function printModelHints(bool $modelExisted): void
+    private function printModelHints(string $path, bool $modelExisted): void
     {
         if (! $modelExisted) {
             return;
         }
 
+        // What the model already carries decides this, not the flags: running
+        // the same command twice would otherwise advise redeclaring
+        // newFactory(), which is fatal, and registering the event twice.
+        $model = $this->files->get("{$path}/Domain/{$this->aggregate}.php");
         $lines = [];
 
-        if ($this->wants('events')) {
+        if ($this->wants('events') && ! str_contains($model, 'registerDomainEvent')) {
             $lines[] = "in new(): \${$this->variable}->registerDomainEvent({$this->aggregate}Created::new(\${$this->variable}->id));";
         }
 
-        if ($this->wants('factory')) {
-            $lines[] = 'use HasFactory;';
+        if ($this->wants('factory') && ! str_contains($model, 'newFactory')) {
+            $lines[] = 'use HasFactory; (imported from Illuminate\Database\Eloquent\Factories)';
             $lines[] = "protected static function newFactory(): {$this->aggregate}Factory { return {$this->aggregate}Factory::new(); }";
         }
 
@@ -214,6 +233,13 @@ final class MakeAggregateCommand extends ScaffoldCommand
             $this->newLine();
             $this->line("  Create the page at <options=bold>resources/templates/tailwindcss/js/Pages/{$this->plural}/Show.vue</>");
         }
+    }
+
+    private function tableDeclaredIn(string $model): ?string
+    {
+        return preg_match('/protected \$table = \'([^\']+)\';/', $this->files->get($model), $matches) === 1
+            ? $matches[1]
+            : null;
     }
 
     /**

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Console\Commands;
+
+use Illuminate\Support\Str;
+
+/**
+ * Class MakeAggregateCommand
+ *
+ * Scaffolds an aggregate inside an existing bounded context, and wires it
+ * into that context's service provider.
+ *
+ * Only the core is generated: the aggregate root, its repository contract
+ * and Eloquent implementation, and its exceptions. Everything else is opt
+ * in, because real aggregates rarely need every layer.
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+final class MakeAggregateCommand extends ScaffoldCommand
+{
+    protected $signature = 'ldd:make:aggregate
+        {context : The bounded context it belongs to, e.g. Billing}
+        {name : The aggregate root name, singular, e.g. Invoice}
+        {--migration : Add a migration and register its path}
+        {--factory : Add a model factory}
+        {--events : Add a Created domain event and record it}
+        {--requests : Add a form request}
+        {--api : Add an API controller}
+        {--all : Everything above}
+        {--force : Overwrite files that already exist}';
+
+    protected $description = 'Create an aggregate inside a bounded context';
+
+    private string $context;
+
+    private string $aggregate;
+
+    private string $plural;
+
+    private string $variable;
+
+    private string $table;
+
+    public function handle(): int
+    {
+        $this->context = Str::studly((string) $this->argument('context'));
+        $this->aggregate = Str::studly(Str::singular((string) $this->argument('name')));
+        $this->plural = Str::plural($this->aggregate);
+        $this->variable = Str::camel($this->aggregate);
+        $this->table = Str::snake($this->plural);
+
+        if (! $this->files->isDirectory(app_path($this->context))) {
+            $this->components->error("The bounded context [{$this->context}] does not exist.");
+            $this->components->bulletList([
+                "Create it with: php artisan ldd:make:bounded-context {$this->context}",
+            ]);
+
+            return self::FAILURE;
+        }
+
+        $path = app_path("{$this->context}/{$this->plural}");
+
+        if ($this->files->isDirectory($path) && ! $this->option('force')) {
+            $this->components->error("The aggregate [{$this->plural}] already exists in [{$this->context}].");
+
+            return self::FAILURE;
+        }
+
+        $this->writeCore($path);
+        $this->writeOptional($path);
+        $this->wireProvider();
+
+        $this->newLine();
+        $this->components->info("Aggregate [{$this->aggregate}] created in [{$this->context}].");
+
+        if ($this->wants('api')) {
+            $this->components->bulletList([
+                "Register the controller in app/{$this->context}/Shared/Infrastructure/Http/Routes/api.php",
+            ]);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function wants(string $option): bool
+    {
+        return (bool) ($this->option($option) || $this->option('all'));
+    }
+
+    private function writeCore(string $path): void
+    {
+        $uses = [];
+
+        if ($this->wants('events')) {
+            $uses[] = "App\\{$this->context}\\{$this->plural}\\Domain\\Events\\{$this->aggregate}Created";
+        }
+
+        if ($this->wants('factory')) {
+            // The factory lives in Infrastructure and Laravel would not find
+            // it by convention, so the model points at it explicitly. This is
+            // the coupling the architecture test exempts for aggregate roots.
+            $uses[] = "App\\{$this->context}\\{$this->plural}\\Infrastructure\\Persistence\\{$this->aggregate}Factory";
+            $uses[] = 'Illuminate\Database\Eloquent\Factories\HasFactory';
+        }
+
+        $model = $this->stub('aggregate.model', $this->replacements([
+            '{{ modelUses }}' => '',
+            '{{ modelTraits }}' => $this->wants('factory') ? "    use HasFactory;\n" : '',
+            '{{ modelRegisterEvent }}' => $this->wants('events')
+                ? "        \${$this->variable}->registerDomainEvent({$this->aggregate}Created::new(\${$this->variable}->id));\n"
+                : '',
+            '{{ modelFactoryMethod }}' => $this->wants('factory')
+                ? "\n    protected static function newFactory(): {$this->aggregate}Factory\n    {\n        return {$this->aggregate}Factory::new();\n    }\n"
+                : '',
+        ]));
+
+        foreach ($uses as $class) {
+            $model = $this->withImport($model, $class);
+        }
+
+        $this->put("{$path}/Domain/{$this->aggregate}.php", $model);
+
+        $this->put("{$path}/Domain/Contracts/{$this->aggregate}Repository.php", $this->stub('aggregate.repository', $this->replacements()));
+        $this->put("{$path}/Domain/Exceptions/{$this->aggregate}Exception.php", $this->stub('aggregate.exception', $this->replacements()));
+        $this->put("{$path}/Domain/Exceptions/{$this->aggregate}NotFound.php", $this->stub('aggregate.not-found', $this->replacements()));
+        $this->put("{$path}/Infrastructure/Persistence/Eloquent{$this->aggregate}Repository.php", $this->stub('aggregate.eloquent-repository', $this->replacements()));
+    }
+
+    private function writeOptional(string $path): void
+    {
+        if ($this->wants('events')) {
+            $this->put("{$path}/Domain/Events/{$this->aggregate}Created.php", $this->stub('aggregate.event', $this->replacements()));
+        }
+
+        if ($this->wants('factory')) {
+            $this->put("{$path}/Infrastructure/Persistence/{$this->aggregate}Factory.php", $this->stub('aggregate.factory', $this->replacements()));
+        }
+
+        if ($this->wants('migration')) {
+            $name = date('Y_m_d_His')."_create_{$this->table}_table.php";
+            $this->put("{$path}/Infrastructure/Persistence/Migrations/{$name}", $this->stub('aggregate.migration', $this->replacements()));
+        }
+
+        if ($this->wants('requests')) {
+            $this->put("{$path}/Infrastructure/Http/Requests/Store{$this->aggregate}Request.php", $this->stub('aggregate.request', $this->replacements()));
+        }
+
+        if ($this->wants('api')) {
+            $this->put("{$path}/Infrastructure/Http/Controllers/API/{$this->aggregate}Controller.php", $this->stub('aggregate.api-controller', $this->replacements()));
+        }
+    }
+
+    /**
+     * Binds the repository and, when a migration was generated, registers its
+     * path. Without this the aggregate would resolve nothing and its tables
+     * would never be created — silently, in both cases.
+     */
+    private function wireProvider(): void
+    {
+        $file = app_path("{$this->context}/{$this->context}ServiceProvider.php");
+
+        if (! $this->files->exists($file)) {
+            $this->components->twoColumnDetail($this->relative($file), '<fg=yellow>missing, not wired</>');
+
+            return;
+        }
+
+        $contract = "App\\{$this->context}\\{$this->plural}\\Domain\\Contracts\\{$this->aggregate}Repository";
+        $eloquent = "App\\{$this->context}\\{$this->plural}\\Infrastructure\\Persistence\\Eloquent{$this->aggregate}Repository";
+        $binding = "        {$this->aggregate}Repository::class => Eloquent{$this->aggregate}Repository::class,";
+
+        $contents = $this->files->get($file);
+
+        if (! str_contains($contents, $binding)) {
+            $contents = $this->withImport($this->withImport($contents, $contract), $eloquent);
+            $contents = $this->appendToArray($contents, 'bindings', $binding);
+        }
+
+        if ($this->wants('migration')) {
+            $entry = "        __DIR__.'/{$this->plural}/Infrastructure/Persistence/Migrations',";
+
+            if (! str_contains($contents, $entry)) {
+                $contents = $this->appendToArray($contents, 'migrations', $entry);
+            }
+        }
+
+        $this->files->put($file, $contents);
+        $this->components->twoColumnDetail($this->relative($file), '<fg=green>wired</>');
+    }
+
+    /**
+     * Appends an entry to a declared property array, whether it is currently
+     * empty or already populated.
+     */
+    private function appendToArray(string $contents, string $property, string $entry): string
+    {
+        $empty = "array \${$property} = [];";
+
+        if (str_contains($contents, $empty)) {
+            return str_replace($empty, "array \${$property} = [\n{$entry}\n    ];", $contents);
+        }
+
+        return (string) preg_replace(
+            '/(array \$'.$property.' = \[\n)(.*?)(    \];)/s',
+            "$1$2{$entry}\n$3",
+            $contents,
+            1
+        );
+    }
+
+    /**
+     * @param  array<string, string>  $extra
+     * @return array<string, string>
+     */
+    private function replacements(array $extra = []): array
+    {
+        return array_merge([
+            '{{ context }}' => $this->context,
+            '{{ aggregate }}' => $this->aggregate,
+            '{{ plural }}' => $this->plural,
+            '{{ variable }}' => $this->variable,
+            '{{ table }}' => $this->table,
+            '{{ author }}' => config('app.scaffold_author', 'Unay Santisteban <usantisteban@othercode.io>'),
+        ], $extra);
+    }
+}

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -30,6 +30,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
         {--web : Add an Inertia controller}
         {--api : Add an API controller}
         {--all : Everything above}
+        {--table= : Table name, defaults to the pluralised aggregate}
         {--force : Overwrite files that already exist}';
 
     protected $description = 'Create an aggregate inside a bounded context';
@@ -47,7 +48,10 @@ final class MakeAggregateCommand extends ScaffoldCommand
     public function handle(): int
     {
         $context = $this->identifier((string) $this->argument('context'), 'bounded context');
-        $aggregate = $this->identifier(Str::singular((string) $this->argument('name')), 'aggregate');
+
+        // The name is taken as written. Singularising it turns Analysis into
+        // Analysi, and no heuristic tells that apart from a real plural.
+        $aggregate = $this->identifier((string) $this->argument('name'), 'aggregate');
 
         if ($context === null || $aggregate === null) {
             return self::FAILURE;
@@ -57,7 +61,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $this->aggregate = $aggregate;
         $this->plural = Str::plural($this->aggregate);
         $this->variable = Str::camel($this->aggregate);
-        $this->table = Str::snake($this->plural);
+        $this->table = (string) ($this->option('table') ?: Str::snake($this->plural));
 
         if ($this->context === self::SHARED_CONTEXT) {
             $this->components->error('[Shared] is the foundation layer, not a bounded context that can own aggregates.');
@@ -84,16 +88,30 @@ final class MakeAggregateCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
-        $this->writeCore($path);
+        if ($this->wants('migration') && ($owner = $this->tableOwnedElsewhere()) !== null) {
+            $this->components->error("Table [{$this->table}] already has a create migration in [{$owner}].");
+            $this->components->bulletList([
+                "Pass a different name with: --table={$this->context}_{$this->table}",
+            ]);
+
+            return self::FAILURE;
+        }
+
+        if (! $this->writeCore($path)) {
+            return self::FAILURE;
+        }
+
         $this->writeOptional($path);
-        $this->wireProvider();
+        $wired = $this->wireProvider();
 
         $this->newLine();
         $this->components->info("Aggregate [{$this->aggregate}] created in [{$this->context}].");
 
         $this->printRouteHints();
 
-        return self::SUCCESS;
+        // The files exist but the context does not know about them, so a
+        // script chaining on this command must not treat it as done.
+        return $wired ? self::SUCCESS : self::FAILURE;
     }
 
     /**
@@ -120,12 +138,34 @@ final class MakeAggregateCommand extends ScaffoldCommand
         }
     }
 
+    /**
+     * Reusing an aggregate name across contexts is normal in DDD, but the
+     * table name is global: two create migrations for the same table abort
+     * `migrate` on a fresh database. Returns the context that already owns it.
+     */
+    private function tableOwnedElsewhere(): ?string
+    {
+        $mine = app_path("{$this->context}/{$this->plural}/Infrastructure/Persistence/Migrations");
+
+        foreach ($this->files->glob(app_path('*/*/Infrastructure/Persistence/Migrations')) ?: [] as $dir) {
+            if ($dir === $mine) {
+                continue;
+            }
+
+            if (($this->files->glob("{$dir}/*_create_{$this->table}_table.php") ?: []) !== []) {
+                return $this->relative($dir);
+            }
+        }
+
+        return null;
+    }
+
     private function wants(string $option): bool
     {
         return (bool) ($this->option($option) || $this->option('all'));
     }
 
-    private function writeCore(string $path): void
+    private function writeCore(string $path): bool
     {
         $uses = [];
 
@@ -153,7 +193,17 @@ final class MakeAggregateCommand extends ScaffoldCommand
         ]));
 
         foreach ($uses as $class) {
-            $model = $this->withImport($model, $class);
+            $imported = $this->withImport($model, $class);
+
+            // stubs/ is meant to be edited, so a stub with no namespace line
+            // is reachable. Say so rather than dying on a TypeError.
+            if ($imported === null) {
+                $this->components->error("Could not add [{$class}] to the model: stubs/aggregate.model.stub needs a namespace declaration.");
+
+                return false;
+            }
+
+            $model = $imported;
         }
 
         $this->put("{$path}/Domain/{$this->aggregate}.php", $model);
@@ -162,6 +212,8 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $this->put("{$path}/Domain/Exceptions/{$this->aggregate}Exception.php", $this->stub('aggregate.exception', $this->replacements()));
         $this->put("{$path}/Domain/Exceptions/{$this->aggregate}NotFound.php", $this->stub('aggregate.not-found', $this->replacements()));
         $this->put("{$path}/Infrastructure/Persistence/Eloquent{$this->aggregate}Repository.php", $this->stub('aggregate.eloquent-repository', $this->replacements()));
+
+        return true;
     }
 
     private function writeOptional(string $path): void
@@ -206,15 +258,9 @@ final class MakeAggregateCommand extends ScaffoldCommand
      * path. Without this the aggregate would resolve nothing and its tables
      * would never be created — silently, in both cases.
      */
-    private function wireProvider(): void
+    private function wireProvider(): bool
     {
         $file = app_path("{$this->context}/{$this->context}ServiceProvider.php");
-
-        if (! $this->files->exists($file)) {
-            $this->components->twoColumnDetail($this->relative($file), '<fg=yellow>missing, not wired</>');
-
-            return;
-        }
 
         $contract = "App\\{$this->context}\\{$this->plural}\\Domain\\Contracts\\{$this->aggregate}Repository";
         $eloquent = "App\\{$this->context}\\{$this->plural}\\Infrastructure\\Persistence\\Eloquent{$this->aggregate}Repository";
@@ -222,7 +268,15 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
         $contents = $this->files->get($file);
 
-        if (! str_contains($contents, $binding)) {
+        // Matching the generated line verbatim would miss a reformatted or
+        // re-indented provider and append the binding a second time, silently
+        // overriding whatever the first one pointed at.
+        $alreadyBound = preg_match(
+            '/\b'.preg_quote("{$this->aggregate}Repository", '/').'::class\s*=>/',
+            $contents
+        ) === 1;
+
+        if (! $alreadyBound) {
             $contents = $this->withImport($contents, $contract);
             $contents = $contents === null ? null : $this->withImport($contents, $eloquent);
             $contents = $contents === null ? null : $this->appendToArray($contents, 'bindings', $binding);
@@ -243,11 +297,13 @@ final class MakeAggregateCommand extends ScaffoldCommand
             $this->components->twoColumnDetail($this->relative($file), '<fg=red>could not be wired</>');
             $this->components->warn("Add the binding and, if generated, the migration path to {$this->context}ServiceProvider by hand.");
 
-            return;
+            return false;
         }
 
         $this->files->put($file, $contents);
         $this->components->twoColumnDetail($this->relative($file), '<fg=green>wired</>');
+
+        return true;
     }
 
     /**
@@ -280,8 +336,22 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
         // Declared inline, e.g. `public array $bindings = [Foo::class => Bar::class];`
         $inline = preg_replace_callback(
-            '/array \$'.preg_quote($property, '/').' = \[(.+?)\];/s',
-            fn (array $m): string => "array \${$property} = [\n        ".trim($m[1], " \n").(str_ends_with(trim($m[1]), ',') ? '' : ',')."\n{$entry}\n    ];",
+            '/array \$'.preg_quote($property, '/').' = \[(.*?)\];/s',
+            function (array $m) use ($property, $entry): string {
+                $body = $m[1];
+
+                // A body that is only whitespace or comments holds no elements:
+                // emitting it as one produces `[,` and a parse error.
+                $hasElements = trim((string) preg_replace('#/\*.*?\*/|//[^\n]*#s', '', $body)) !== '';
+
+                if (! $hasElements) {
+                    return "array \${$property} = [".rtrim($body)."\n{$entry}\n    ];";
+                }
+
+                $existing = rtrim(trim($body), ',');
+
+                return "array \${$property} = [\n        {$existing},\n{$entry}\n    ];";
+            },
             $contents,
             1,
             $count

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -213,6 +213,15 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
             $file = "{$dir}/{$kind}.php";
 
+            // What the route file already holds decides this, not the flags.
+            // A developer who has declared the route may well have put it
+            // behind middleware, and pasting the canonical one back replaces
+            // it: RouteCollection keys by method and URI.
+            if ($this->files->exists($file)
+                && str_contains($this->files->get($file), "{$this->aggregate}Controller")) {
+                continue;
+            }
+
             $this->newLine();
             $this->line("  Add to <options=bold>{$this->relative($file)}</>:");
 
@@ -229,9 +238,11 @@ final class MakeAggregateCommand extends ScaffoldCommand
             }
         }
 
-        if ($this->wants('web')) {
+        $page = base_path("resources/templates/tailwindcss/js/Pages/{$this->plural}/Show.vue");
+
+        if ($this->wants('web') && ! $this->files->exists($page)) {
             $this->newLine();
-            $this->line("  Create the page at <options=bold>resources/templates/tailwindcss/js/Pages/{$this->plural}/Show.vue</>");
+            $this->line("  Create the page at <options=bold>{$this->relative($page)}</>");
         }
     }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -46,13 +46,28 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
     public function handle(): int
     {
-        $this->context = Str::studly((string) $this->argument('context'));
-        $this->aggregate = Str::studly(Str::singular((string) $this->argument('name')));
+        $context = $this->identifier((string) $this->argument('context'), 'bounded context');
+        $aggregate = $this->identifier(Str::singular((string) $this->argument('name')), 'aggregate');
+
+        if ($context === null || $aggregate === null) {
+            return self::FAILURE;
+        }
+
+        $this->context = $context;
+        $this->aggregate = $aggregate;
         $this->plural = Str::plural($this->aggregate);
         $this->variable = Str::camel($this->aggregate);
         $this->table = Str::snake($this->plural);
 
-        if (! $this->files->isDirectory(app_path($this->context))) {
+        if ($this->context === self::SHARED_CONTEXT) {
+            $this->components->error('[Shared] is the foundation layer, not a bounded context that can own aggregates.');
+
+            return self::FAILURE;
+        }
+
+        // A directory alone is not a context: it also has to be wired by a
+        // provider named after it, which is what this command edits.
+        if (! $this->files->exists(app_path("{$this->context}/{$this->context}ServiceProvider.php"))) {
             $this->components->error("The bounded context [{$this->context}] does not exist.");
             $this->components->bulletList([
                 "Create it with: php artisan ldd:make:bounded-context {$this->context}",
@@ -94,14 +109,14 @@ final class MakeAggregateCommand extends ScaffoldCommand
         if ($this->wants('web')) {
             $this->newLine();
             $this->line("  Add to <options=bold>{$this->relative($routes)}/web.php</>:");
-            $this->line("  <fg=gray>Route::get('/{$slug}', [{$this->aggregate}Controller::class, 'index'])->name('{$slug}.index');</>");
-            $this->line("  and create the page at <options=bold>resources/templates/tailwindcss/js/Pages/{$this->plural}/Index.vue</>");
+            $this->line("  <fg=gray>Route::get('/{$slug}/{id}', [{$this->aggregate}Controller::class, 'show'])->name('{$slug}.show');</>");
+            $this->line("  and create the page at <options=bold>resources/templates/tailwindcss/js/Pages/{$this->plural}/Show.vue</>");
         }
 
         if ($this->wants('api')) {
             $this->newLine();
             $this->line("  Add to <options=bold>{$this->relative($routes)}/api.php</>:");
-            $this->line("  <fg=gray>Route::get('/{$slug}', [{$this->aggregate}Controller::class, 'index'])->name('{$slug}.index');</>");
+            $this->line("  <fg=gray>Route::get('/{$slug}/{id}', [{$this->aggregate}Controller::class, 'show'])->name('{$slug}.show');</>");
         }
     }
 
@@ -160,8 +175,17 @@ final class MakeAggregateCommand extends ScaffoldCommand
         }
 
         if ($this->wants('migration')) {
-            $name = date('Y_m_d_His')."_create_{$this->table}_table.php";
-            $this->put("{$path}/Infrastructure/Persistence/Migrations/{$name}", $this->stub('aggregate.migration', $this->replacements()));
+            $dir = "{$path}/Infrastructure/Persistence/Migrations";
+
+            // The filename carries a timestamp, so regenerating would drop a
+            // second create-table migration beside the first and break
+            // `migrate` with "table already exists". Reuse the existing one.
+            $existing = $this->files->glob("{$dir}/*_create_{$this->table}_table.php") ?: [];
+
+            $this->put(
+                $existing[0] ?? "{$dir}/".date('Y_m_d_His')."_create_{$this->table}_table.php",
+                $this->stub('aggregate.migration', $this->replacements())
+            );
         }
 
         if ($this->wants('requests')) {
@@ -199,11 +223,12 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $contents = $this->files->get($file);
 
         if (! str_contains($contents, $binding)) {
-            $contents = $this->withImport($this->withImport($contents, $contract), $eloquent);
-            $contents = $this->appendToArray($contents, 'bindings', $binding);
+            $contents = $this->withImport($contents, $contract);
+            $contents = $contents === null ? null : $this->withImport($contents, $eloquent);
+            $contents = $contents === null ? null : $this->appendToArray($contents, 'bindings', $binding);
         }
 
-        if ($this->wants('migration')) {
+        if ($contents !== null && $this->wants('migration')) {
             $entry = "        __DIR__.'/{$this->plural}/Infrastructure/Persistence/Migrations',";
 
             if (! str_contains($contents, $entry)) {
@@ -211,15 +236,28 @@ final class MakeAggregateCommand extends ScaffoldCommand
             }
         }
 
+        // Reporting a green "wired" after a rewrite that matched nothing is
+        // how an unbound contract and an unregistered migration path reach
+        // production unnoticed. Say so instead.
+        if ($contents === null) {
+            $this->components->twoColumnDetail($this->relative($file), '<fg=red>could not be wired</>');
+            $this->components->warn("Add the binding and, if generated, the migration path to {$this->context}ServiceProvider by hand.");
+
+            return;
+        }
+
         $this->files->put($file, $contents);
         $this->components->twoColumnDetail($this->relative($file), '<fg=green>wired</>');
     }
 
     /**
-     * Appends an entry to a declared property array, whether it is currently
-     * empty or already populated.
+     * Appends an entry to a declared property array, whatever shape it is
+     * currently written in.
+     *
+     * Returns null when the property cannot be found, so the caller can
+     * report a failure rather than silently rewriting the file unchanged.
      */
-    private function appendToArray(string $contents, string $property, string $entry): string
+    private function appendToArray(string $contents, string $property, string $entry): ?string
     {
         $empty = "array \${$property} = [];";
 
@@ -227,12 +265,29 @@ final class MakeAggregateCommand extends ScaffoldCommand
             return str_replace($empty, "array \${$property} = [\n{$entry}\n    ];", $contents);
         }
 
-        return (string) preg_replace(
-            '/(array \$'.$property.' = \[\n)(.*?)(    \];)/s',
-            "$1$2{$entry}\n$3",
+        // Already populated and spread over several lines.
+        $multiline = preg_replace_callback(
+            '/(array \$'.preg_quote($property, '/').' = \[\n)(.*?)(^    \];)/ms',
+            fn (array $m): string => $m[1].$m[2].$entry."\n".$m[3],
             $contents,
-            1
+            1,
+            $count
         );
+
+        if ($count > 0) {
+            return $multiline;
+        }
+
+        // Declared inline, e.g. `public array $bindings = [Foo::class => Bar::class];`
+        $inline = preg_replace_callback(
+            '/array \$'.preg_quote($property, '/').' = \[(.+?)\];/s',
+            fn (array $m): string => "array \${$property} = [\n        ".trim($m[1], " \n").(str_ends_with(trim($m[1]), ',') ? '' : ',')."\n{$entry}\n    ];",
+            $contents,
+            1,
+            $count
+        );
+
+        return $count > 0 ? $inline : null;
     }
 
     /**
@@ -248,7 +303,6 @@ final class MakeAggregateCommand extends ScaffoldCommand
             '{{ variable }}' => $this->variable,
             '{{ pluralVariable }}' => Str::camel($this->plural),
             '{{ table }}' => $this->table,
-            '{{ author }}' => config('app.scaffold_author', 'Unay Santisteban <usantisteban@othercode.io>'),
         ], $extra);
     }
 }

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -30,8 +30,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
         {--web : Add an Inertia controller}
         {--api : Add an API controller}
         {--all : Everything above}
-        {--table= : Table name, defaults to the pluralised aggregate}
-        {--force : Overwrite files that already exist}';
+        {--table= : Table name, defaults to the pluralised aggregate}';
 
     protected $description = 'Create an aggregate inside a bounded context';
 
@@ -92,11 +91,10 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
         $path = app_path("{$this->context}/{$this->plural}");
 
-        if ($this->files->isDirectory($path) && ! $this->option('force')) {
-            $this->components->error("The aggregate [{$this->plural}] already exists in [{$this->context}].");
-
-            return self::FAILURE;
-        }
+        // Running this again is how you add an option you skipped, so nothing
+        // already on disk is rewritten: the model may have been worked on and
+        // the migration may already have been applied.
+        $modelExisted = $this->files->exists("{$path}/Domain/{$this->aggregate}.php");
 
         if ($this->wants('migration') && ($owner = $this->tableOwnedElsewhere()) !== null) {
             $this->components->error("Table [{$this->table}] already has a create migration in [{$owner}].");
@@ -115,13 +113,48 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $wired = $this->wireProvider();
 
         $this->newLine();
-        $this->components->info("Aggregate [{$this->aggregate}] created in [{$this->context}].");
+        $this->components->info("Aggregate [{$this->aggregate}] ".($modelExisted ? 'updated' : 'created')." in [{$this->context}].");
 
+        $this->printModelHints($modelExisted);
         $this->printRouteHints();
 
         // The files exist but the context does not know about them, so a
         // script chaining on this command must not treat it as done.
         return $wired ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * The model carries the wiring for --events and --factory, and it is not
+     * rewritten once it exists. Adding either option later costs a line or
+     * two by hand, which is the price of never losing what the model grew.
+     */
+    private function printModelHints(bool $modelExisted): void
+    {
+        if (! $modelExisted) {
+            return;
+        }
+
+        $lines = [];
+
+        if ($this->wants('events')) {
+            $lines[] = "in new(): \${$this->variable}->registerDomainEvent({$this->aggregate}Created::new(\${$this->variable}->id));";
+        }
+
+        if ($this->wants('factory')) {
+            $lines[] = 'use HasFactory;';
+            $lines[] = "protected static function newFactory(): {$this->aggregate}Factory { return {$this->aggregate}Factory::new(); }";
+        }
+
+        if ($lines === []) {
+            return;
+        }
+
+        $this->newLine();
+        $this->line("  <fg=yellow>{$this->aggregate} was left as it is. Add to it by hand:</>");
+
+        foreach ($lines as $line) {
+            $this->line("  <fg=gray>{$line}</>");
+        }
     }
 
     /**

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -134,10 +134,17 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $dir = app_path("{$this->context}/Shared/Infrastructure/Http/Routes");
         $slug = Str::kebab($this->plural);
 
-        // A route name is global, so web and api cannot share one: Laravel
-        // keeps both routes but resolves route() to whichever was registered
-        // first, leaving the other unreachable by name.
-        foreach (['web' => '', 'api' => 'api.'] as $kind => $prefix) {
+        // Web and api must differ in both URI and name. RouteCollection keys
+        // routes by method and URI, so reusing the URI replaces the web route
+        // outright instead of adding a second one; and a route name is global,
+        // so sharing that resolves route() to whichever came first. The api
+        // file gets no URI prefix of its own, hence carrying it in the path.
+        $routes = [
+            'web' => ['uri' => "/{$slug}", 'name' => "{$slug}.show"],
+            'api' => ['uri' => "/api/{$slug}", 'name' => "api.{$slug}.show"],
+        ];
+
+        foreach ($routes as $kind => $route) {
             if (! $this->wants($kind)) {
                 continue;
             }
@@ -146,7 +153,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
             $this->newLine();
             $this->line("  Add to <options=bold>{$this->relative($file)}</>:");
-            $this->line("  <fg=gray>Route::get('/{$slug}/{id}', [{$this->aggregate}Controller::class, 'show'])->name('{$prefix}{$slug}.show');</>");
+            $this->line("  <fg=gray>Route::get('{$route['uri']}/{id}', [{$this->aggregate}Controller::class, 'show'])->name('{$route['name']}');</>");
 
             if ($kind === 'api') {
                 $this->line("  <fg=gray>// importing the {$this->aggregate}Controller under Http\\Controllers\\API</>");

--- a/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
@@ -50,7 +50,7 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
 
         $this->writeProvider($context, $path);
         $this->writeRoutes($context, $path);
-        $this->registerProvider($context);
+        $registered = $this->registerProvider($context);
 
         $this->newLine();
         $this->components->info("Bounded context [{$context}] created.");
@@ -58,7 +58,9 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
             "Add aggregates with: php artisan ldd:make:aggregate {$context} <Aggregate>",
         ]);
 
-        return self::SUCCESS;
+        // The files exist but nothing loads them, so a script chaining on this
+        // command must not treat it as done.
+        return $registered ? self::SUCCESS : self::FAILURE;
     }
 
     private function writeProvider(string $context, string $path): void
@@ -127,36 +129,46 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
      * Adds the provider to bootstrap/providers.php, keeping the list sorted
      * the way the file already is.
      */
-    private function registerProvider(string $context): void
+    private function registerProvider(string $context): bool
     {
         $file = base_path('bootstrap/providers.php');
         $contents = $this->files->get($file);
         $class = "App\\{$context}\\{$context}ServiceProvider";
 
-        if (str_contains($contents, $class)) {
+        // Looking for the fully qualified name would also match the import
+        // this command adds, so a run that added the import but never reached
+        // the list would report itself as already registered for ever after.
+        // The lookbehind keeps Probe from matching SubProbeServiceProvider.
+        $registered = preg_match(
+            '/(?<![\w\\\\])'.preg_quote($context, '/').'ServiceProvider::class/',
+            $contents
+        ) === 1;
+
+        if ($registered) {
             $this->components->twoColumnDetail('bootstrap/providers.php', '<fg=yellow>already registered</>');
 
-            return;
+            return true;
         }
 
         $imported = $this->withImport($contents, $class);
 
-        // Appending the short class name without its import would leave an
-        // unqualified reference and a fatal on the next boot.
-        if ($imported === null) {
-            $this->components->twoColumnDetail('bootstrap/providers.php', '<fg=red>could not be updated</>');
-            $this->components->warn("Register {$class} by hand.");
+        $updated = $imported === null
+            ? null
+            : $this->appendToList($imported, 'return [', "    {$context}ServiceProvider::class,", '');
 
-            return;
+        // Appending the short name without its import leaves an unqualified
+        // reference, and adding the import without the entry leaves a context
+        // nothing ever loads. Both are silent, so neither may report green.
+        if ($updated === null) {
+            $this->components->twoColumnDetail('bootstrap/providers.php', '<fg=red>could not be updated</>');
+            $this->components->warn("Register {$class} in bootstrap/providers.php by hand.");
+
+            return false;
         }
 
-        $contents = str_replace(
-            "\n];",
-            "\n    {$context}ServiceProvider::class,\n];",
-            $imported
-        );
-
-        $this->files->put($file, $contents);
+        $this->files->put($file, $updated);
         $this->components->twoColumnDetail('bootstrap/providers.php', '<fg=green>updated</>');
+
+        return true;
     }
 }

--- a/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
@@ -135,14 +135,14 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
         $contents = $this->files->get($file);
         $class = "App\\{$context}\\{$context}ServiceProvider";
 
-        // Looking for the fully qualified name would also match the import
-        // this command adds, so a run that added the import but never reached
-        // the list would report itself as already registered for ever after.
-        // The lookbehind keeps Probe from matching SubProbeServiceProvider.
-        $registered = preg_match(
-            '/(?<![\w\\\\])'.preg_quote($context, '/').'ServiceProvider::class/',
-            $contents
-        ) === 1;
+        // Both shapes count as registered: Laravel's own providers.php lists
+        // classes fully qualified, while this command adds an import and the
+        // short name. Matching the bare class name would also match the
+        // import, so a run that added the import but never reached the list
+        // would report itself as already registered for ever after; the
+        // lookbehind keeps Probe from matching SubProbeServiceProvider.
+        $registered = str_contains($contents, $class.'::class')
+            || preg_match('/(?<![\w\\\\])'.preg_quote($context, '/').'ServiceProvider::class/', $contents) === 1;
 
         if ($registered) {
             $this->components->twoColumnDetail('bootstrap/providers.php', '<fg=yellow>already registered</>');

--- a/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Console\Commands;
 
-use Illuminate\Support\Str;
-
 /**
  * Class MakeBoundedContextCommand
  *
@@ -30,16 +28,16 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
 
     public function handle(): int
     {
-        $context = Str::studly((string) $this->argument('name'));
+        $context = $this->identifier((string) $this->argument('name'), 'bounded context');
 
-        if ($context === '') {
-            $this->components->error('The bounded context name cannot be empty.');
-
+        if ($context === null) {
             return self::FAILURE;
         }
 
-        if ($context !== $this->argument('name')) {
-            $this->components->info("Using [{$context}] as the context name.");
+        if ($context === self::SHARED_CONTEXT) {
+            $this->components->error('[Shared] already exists as the application foundation layer.');
+
+            return self::FAILURE;
         }
 
         $path = app_path($context);
@@ -141,10 +139,21 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
             return;
         }
 
+        $imported = $this->withImport($contents, $class);
+
+        // Appending the short class name without its import would leave an
+        // unqualified reference and a fatal on the next boot.
+        if ($imported === null) {
+            $this->components->twoColumnDetail('bootstrap/providers.php', '<fg=red>could not be updated</>');
+            $this->components->warn("Register {$class} by hand.");
+
+            return;
+        }
+
         $contents = str_replace(
             "\n];",
             "\n    {$context}ServiceProvider::class,\n];",
-            $this->withImport($contents, $class)
+            $imported
         );
 
         $this->files->put($file, $contents);

--- a/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Console\Commands;
 
-use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 
 /**
@@ -20,7 +18,7 @@ use Illuminate\Support\Str;
  *
  * @author Unay Santisteban <usantisteban@othercode.io>
  */
-final class MakeBoundedContextCommand extends Command
+final class MakeBoundedContextCommand extends ScaffoldCommand
 {
     protected $signature = 'ldd:make:bounded-context
         {name : The bounded context name, e.g. VisaManagement}
@@ -29,11 +27,6 @@ final class MakeBoundedContextCommand extends Command
         {--force : Overwrite files that already exist}';
 
     protected $description = 'Create a bounded context with its service provider';
-
-    public function __construct(private readonly Filesystem $files)
-    {
-        parent::__construct();
-    }
 
     public function handle(): int
     {
@@ -74,7 +67,8 @@ final class MakeBoundedContextCommand extends Command
     {
         $this->put(
             $path."/{$context}ServiceProvider.php",
-            $this->stub('bounded-context.provider', $context, [
+            $this->stub('bounded-context.provider', [
+                '{{ context }}' => $context,
                 '{{ routes }}' => $this->routesProperty($context),
             ])
         );
@@ -89,7 +83,7 @@ final class MakeBoundedContextCommand extends Command
 
             $this->put(
                 $path."/Shared/Infrastructure/Http/Routes/{$kind}.php",
-                $this->stub("bounded-context.routes.{$kind}", $context)
+                $this->stub("bounded-context.routes.{$kind}", ['{{ context }}' => $context])
             );
         }
     }
@@ -147,58 +141,13 @@ final class MakeBoundedContextCommand extends Command
             return;
         }
 
-        // Imports are kept alphabetical, otherwise Pint's ordered_imports
-        // fixer would fail on every generated context.
-        preg_match_all('/^use (.+);$/m', $contents, $matches);
-        $imports = $matches[1];
-        $imports[] = $class;
-        sort($imports);
-
-        $contents = preg_replace(
-            '/^use .+;\n(use .+;\n)*/m',
-            implode('', array_map(fn (string $i): string => "use {$i};\n", $imports)),
-            $contents,
-            1
-        );
-
         $contents = str_replace(
             "\n];",
             "\n    {$context}ServiceProvider::class,\n];",
-            (string) $contents
+            $this->withImport($contents, $class)
         );
 
         $this->files->put($file, $contents);
         $this->components->twoColumnDetail('bootstrap/providers.php', '<fg=green>updated</>');
-    }
-
-    /**
-     * @param  array<string, string>  $replacements
-     */
-    private function stub(string $name, string $context, array $replacements = []): string
-    {
-        return str_replace(
-            array_merge(['{{ context }}'], array_keys($replacements)),
-            array_merge([$context], array_values($replacements)),
-            $this->files->get(base_path("stubs/{$name}.stub"))
-        );
-    }
-
-    private function put(string $path, string $contents): void
-    {
-        if ($this->files->exists($path) && ! $this->option('force')) {
-            $this->components->twoColumnDetail($this->relative($path), '<fg=yellow>exists, skipped</>');
-
-            return;
-        }
-
-        $this->files->ensureDirectoryExists(dirname($path));
-        $this->files->put($path, $contents);
-
-        $this->components->twoColumnDetail($this->relative($path), '<fg=green>created</>');
-    }
-
-    private function relative(string $path): string
-    {
-        return Str::after($path, base_path().DIRECTORY_SEPARATOR);
     }
 }

--- a/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
@@ -48,6 +48,21 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
+        $provider = $path."/{$context}ServiceProvider.php";
+
+        // --force regenerates the provider from the stub. On a context that
+        // has been in use that silently drops every binding, migration path,
+        // listener and command it declares, and the aggregates stay on disk
+        // so the damage only surfaces later as an unresolvable contract.
+        if ($this->files->exists($provider) && ($declared = $this->declaredIn($provider)) !== []) {
+            $this->components->error("[{$context}ServiceProvider] already declares ".implode(' and ', $declared).'.');
+            $this->components->bulletList([
+                'Regenerating it would drop them. Edit the provider by hand, or delete it first.',
+            ]);
+
+            return self::FAILURE;
+        }
+
         $this->writeProvider($context, $path);
         $this->writeRoutes($context, $path);
         $registered = $this->registerProvider($context);
@@ -61,6 +76,35 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
         // The files exist but nothing loads them, so a script chaining on this
         // command must not treat it as done.
         return $registered ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * The provider properties that already hold entries, so regenerating the
+     * file would lose them. A property holding only comments holds nothing.
+     *
+     * @return list<string>
+     */
+    private function declaredIn(string $file): array
+    {
+        $contents = $this->files->get($file);
+        $declared = [];
+
+        foreach (['bindings', 'events', 'commands', 'migrations', 'routes'] as $property) {
+            // Checked first: the non-greedy patterns below would otherwise run
+            // past an empty declaration and close on a later property's array.
+            if (str_contains($contents, "array \${$property} = [];")) {
+                continue;
+            }
+
+            $found = preg_match('/array \$'.$property.' = \[(.*?)^    \];/ms', $contents, $matches) === 1
+                || preg_match('/array \$'.$property.' = \[(.*?)\];/s', $contents, $matches) === 1;
+
+            if ($found && trim((string) preg_replace('#/\*.*?\*/|//[^\n]*#s', '', $matches[1])) !== '') {
+                $declared[] = "\${$property}";
+            }
+        }
+
+        return $declared;
     }
 
     private function writeProvider(string $context, string $path): void

--- a/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
@@ -21,8 +21,7 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
     protected $signature = 'ldd:make:bounded-context
         {name : The bounded context name, e.g. VisaManagement}
         {--web : Add a web routes file}
-        {--api : Add an api routes file}
-        {--force : Overwrite files that already exist}';
+        {--api : Add an api routes file}';
 
     protected $description = 'Create a bounded context with its service provider';
 
@@ -41,70 +40,38 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
         }
 
         $path = app_path($context);
-
-        if ($this->files->isDirectory($path) && ! $this->option('force')) {
-            $this->components->error("The bounded context [{$context}] already exists.");
-
-            return self::FAILURE;
-        }
-
         $provider = $path."/{$context}ServiceProvider.php";
 
-        // --force regenerates the provider from the stub. On a context that
-        // has been in use that silently drops every binding, migration path,
-        // listener and command it declares, and the aggregates stay on disk
-        // so the damage only surfaces later as an unresolvable contract.
-        if ($this->files->exists($provider) && ($declared = $this->declaredIn($provider)) !== []) {
-            $this->components->error("[{$context}ServiceProvider] already declares ".implode(' and ', $declared).'.');
-            $this->components->bulletList([
-                'Regenerating it would drop them. Edit the provider by hand, or delete it first.',
-            ]);
-
-            return self::FAILURE;
-        }
+        // Running this again on a context already in use has to be safe: the
+        // provider is the one file that accumulates hand-written wiring, and
+        // rewriting it from the stub would drop every binding and migration
+        // path while the aggregates stayed on disk.
+        $providerExisted = $this->files->exists($provider);
 
         $this->writeProvider($context, $path);
-        $this->writeRoutes($context, $path);
+        $routes = $this->writeRoutes($context, $path);
         $registered = $this->registerProvider($context);
 
         $this->newLine();
-        $this->components->info("Bounded context [{$context}] created.");
+        $this->components->info("Bounded context [{$context}] ".($providerExisted ? 'updated.' : 'created.'));
         $this->components->bulletList([
             "Add aggregates with: php artisan ldd:make:aggregate {$context} <Aggregate>",
         ]);
 
-        // The files exist but nothing loads them, so a script chaining on this
-        // command must not treat it as done.
-        return $registered ? self::SUCCESS : self::FAILURE;
-    }
+        // A route file the provider does not declare is never loaded, and the
+        // only symptom is a 404.
+        if ($providerExisted && $routes !== []) {
+            $this->newLine();
+            $this->line("  <fg=yellow>{$context}ServiceProvider was left as it is. Declare the new file(s) in its \$routes:</>");
 
-    /**
-     * The provider properties that already hold entries, so regenerating the
-     * file would lose them. A property holding only comments holds nothing.
-     *
-     * @return list<string>
-     */
-    private function declaredIn(string $file): array
-    {
-        $contents = $this->files->get($file);
-        $declared = [];
-
-        foreach (['bindings', 'events', 'commands', 'migrations', 'routes'] as $property) {
-            // Checked first: the non-greedy patterns below would otherwise run
-            // past an empty declaration and close on a later property's array.
-            if (str_contains($contents, "array \${$property} = [];")) {
-                continue;
-            }
-
-            $found = preg_match('/array \$'.$property.' = \[(.*?)^    \];/ms', $contents, $matches) === 1
-                || preg_match('/array \$'.$property.' = \[(.*?)\];/s', $contents, $matches) === 1;
-
-            if ($found && trim((string) preg_replace('#/\*.*?\*/|//[^\n]*#s', '', $matches[1])) !== '') {
-                $declared[] = "\${$property}";
+            foreach ($routes as $kind) {
+                $this->line("  <fg=gray>'{$kind}' => [__DIR__.'/Shared/Infrastructure/Http/Routes/{$kind}.php'],</>");
             }
         }
 
-        return $declared;
+        // The files exist but nothing loads them, so a script chaining on this
+        // command must not treat it as done.
+        return $registered ? self::SUCCESS : self::FAILURE;
     }
 
     private function writeProvider(string $context, string $path): void
@@ -118,18 +85,29 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
         );
     }
 
-    private function writeRoutes(string $context, string $path): void
+    /**
+     * @return list<string> The route files this run actually created.
+     */
+    private function writeRoutes(string $context, string $path): array
     {
+        $created = [];
+
         foreach (['web', 'api'] as $kind) {
             if (! $this->option($kind)) {
                 continue;
             }
 
-            $this->put(
+            $written = $this->put(
                 $path."/Shared/Infrastructure/Http/Routes/{$kind}.php",
                 $this->stub("bounded-context.routes.{$kind}", ['{{ context }}' => $context])
             );
+
+            if ($written) {
+                $created[] = $kind;
+            }
         }
+
+        return $created;
     }
 
     /**

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -12,15 +12,43 @@ use Illuminate\Support\Str;
  * Class ScaffoldCommand
  *
  * Shared plumbing for the ldd:make:* commands: rendering stubs, writing
- * files without clobbering, and reporting what happened.
+ * files without clobbering, and editing PHP sources the way Pint expects.
  *
  * @author Unay Santisteban <usantisteban@othercode.io>
  */
 abstract class ScaffoldCommand extends Command
 {
+    /**
+     * The Shared context is the application's foundation layer, never a
+     * bounded context that can own aggregates.
+     */
+    protected const SHARED_CONTEXT = 'Shared';
+
     public function __construct(protected readonly Filesystem $files)
     {
         parent::__construct();
+    }
+
+    /**
+     * Normalises a name and rejects anything that is not a legal PHP
+     * identifier. Without this the command happily writes `class 2024Report`,
+     * which is a parse error that takes the whole application down.
+     */
+    protected function identifier(string $value, string $label): ?string
+    {
+        $studly = Str::studly($value);
+
+        if (! preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $studly)) {
+            $this->components->error("The {$label} name must be a valid PHP identifier, [{$value}] is not.");
+
+            return null;
+        }
+
+        if ($studly !== $value) {
+            $this->components->info("Using [{$studly}] as the {$label} name.");
+        }
+
+        return $studly;
     }
 
     /**
@@ -57,10 +85,12 @@ abstract class ScaffoldCommand extends Command
     }
 
     /**
-     * Inserts an import in alphabetical order, so the result survives Pint's
-     * ordered_imports fixer.
+     * Inserts an import in the order Pint's ordered_imports fixer expects.
+     *
+     * Returns null when the import cannot be placed, so the caller reports a
+     * failure instead of leaving an unqualified reference behind.
      */
-    protected function withImport(string $contents, string $class): string
+    protected function withImport(string $contents, string $class): ?string
     {
         if (str_contains($contents, "use {$class};")) {
             return $contents;
@@ -69,13 +99,29 @@ abstract class ScaffoldCommand extends Command
         preg_match_all('/^use (.+);$/m', $contents, $matches);
 
         $imports = [...$matches[1], $class];
-        sort($imports);
 
-        return (string) preg_replace(
-            '/^use .+;\n(use .+;\n)*/m',
-            implode('', array_map(fn (string $i): string => "use {$i};\n", $imports)),
-            $contents,
-            1
-        );
+        // Pint compares the namespace separator as a space, so a byte-wise
+        // sort() would order InvoicesLines before Invoices and fail the lint.
+        usort($imports, fn (string $a, string $b): int => str_replace('\\', ' ', $a) <=> str_replace('\\', ' ', $b));
+
+        $block = implode('', array_map(fn (string $i): string => "use {$i};\n", $imports));
+
+        // preg_replace would read backslash sequences in the replacement as
+        // backreferences, silently mangling namespaces such as \20.
+        if ($matches[1] !== []) {
+            return preg_replace_callback('/^use .+;\n(use .+;\n)*/m', fn (): string => $block, $contents, 1);
+        }
+
+        // No imports yet: open a block after the namespace declaration, or
+        // after the opening tag when the file has none.
+        if (preg_match('/^namespace .+;\n/m', $contents) === 1) {
+            return preg_replace_callback('/^namespace .+;\n/m', fn (array $m): string => $m[0]."\n".$block, $contents, 1);
+        }
+
+        if (str_starts_with($contents, "<?php\n")) {
+            return preg_replace_callback('/^<\?php\n/', fn (array $m): string => $m[0]."\n".$block, $contents, 1);
+        }
+
+        return null;
     }
 }

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+/**
+ * Class ScaffoldCommand
+ *
+ * Shared plumbing for the ldd:make:* commands: rendering stubs, writing
+ * files without clobbering, and reporting what happened.
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+abstract class ScaffoldCommand extends Command
+{
+    public function __construct(protected readonly Filesystem $files)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * @param  array<string, string>  $replacements
+     */
+    protected function stub(string $name, array $replacements): string
+    {
+        return str_replace(
+            array_keys($replacements),
+            array_values($replacements),
+            $this->files->get(base_path("stubs/{$name}.stub"))
+        );
+    }
+
+    protected function put(string $path, string $contents): bool
+    {
+        if ($this->files->exists($path) && ! $this->option('force')) {
+            $this->components->twoColumnDetail($this->relative($path), '<fg=yellow>exists, skipped</>');
+
+            return false;
+        }
+
+        $this->files->ensureDirectoryExists(dirname($path));
+        $this->files->put($path, $contents);
+
+        $this->components->twoColumnDetail($this->relative($path), '<fg=green>created</>');
+
+        return true;
+    }
+
+    protected function relative(string $path): string
+    {
+        return Str::after($path, base_path().DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * Inserts an import in alphabetical order, so the result survives Pint's
+     * ordered_imports fixer.
+     */
+    protected function withImport(string $contents, string $class): string
+    {
+        if (str_contains($contents, "use {$class};")) {
+            return $contents;
+        }
+
+        preg_match_all('/^use (.+);$/m', $contents, $matches);
+
+        $imports = [...$matches[1], $class];
+        sort($imports);
+
+        return (string) preg_replace(
+            '/^use .+;\n(use .+;\n)*/m',
+            implode('', array_map(fn (string $i): string => "use {$i};\n", $imports)),
+            $contents,
+            1
+        );
+    }
+}

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -169,4 +169,59 @@ abstract class ScaffoldCommand extends Command
 
         return null;
     }
+
+    /**
+     * Appends an entry to a list literal, whatever shape it is written in.
+     *
+     * $open is the literal that opens the list, e.g. `return [` or
+     * `array $bindings = [`, and $indent the indentation of its closing
+     * bracket.
+     *
+     * Returns null when the list cannot be found, so the caller reports a
+     * failure instead of writing the file back unchanged and calling it done.
+     */
+    protected function appendToList(string $contents, string $open, string $entry, string $indent = '    '): ?string
+    {
+        if (str_contains($contents, $open.'];')) {
+            return str_replace($open.'];', $open."\n{$entry}\n{$indent}];", $contents);
+        }
+
+        // Already populated and spread over several lines.
+        $multiline = preg_replace_callback(
+            '/('.preg_quote($open, '/').'\n)(.*?)(^'.preg_quote($indent, '/').'\];)/ms',
+            fn (array $m): string => $m[1].$m[2].$entry."\n".$m[3],
+            $contents,
+            1,
+            $count
+        );
+
+        if ($count > 0) {
+            return $multiline;
+        }
+
+        // Declared inline, e.g. `public array $bindings = [Foo::class => Bar::class];`
+        $inline = preg_replace_callback(
+            '/'.preg_quote($open, '/').'(.*?)\];/s',
+            function (array $m) use ($open, $entry, $indent): string {
+                $body = $m[1];
+
+                // A body that is only whitespace or comments holds no elements:
+                // emitting it as one produces `[,` and a parse error.
+                $hasElements = trim((string) preg_replace('#/\*.*?\*/|//[^\n]*#s', '', $body)) !== '';
+
+                if (! $hasElements) {
+                    return $open.rtrim($body)."\n{$entry}\n{$indent}];";
+                }
+
+                $existing = rtrim(trim($body), ',');
+
+                return $open."\n{$indent}    {$existing},\n{$entry}\n{$indent}];";
+            },
+            $contents,
+            1,
+            $count
+        );
+
+        return $count > 0 ? $inline : null;
+    }
 }

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -88,9 +88,16 @@ abstract class ScaffoldCommand extends Command
         );
     }
 
+    /**
+     * Writes a file, never over one that is already there.
+     *
+     * These commands scaffold, they do not edit: anything on disk may have
+     * been worked on, and a migration may already have been applied. Running
+     * one again fills in what is missing and reports what it left alone.
+     */
     protected function put(string $path, string $contents): bool
     {
-        if ($this->files->exists($path) && ! $this->option('force')) {
+        if ($this->files->exists($path)) {
             $this->components->twoColumnDetail($this->relative($path), '<fg=yellow>exists, skipped</>');
 
             return false;

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -24,6 +24,25 @@ abstract class ScaffoldCommand extends Command
      */
     protected const SHARED_CONTEXT = 'Shared';
 
+    /**
+     * Words PHP will not accept as a class name. A plain character-class
+     * check lets `Case`, `Match` and `List` through, and those are ordinary
+     * domain nouns that would generate a file which does not parse.
+     *
+     * @var list<string>
+     */
+    private const RESERVED = [
+        'abstract', 'and', 'array', 'as', 'bool', 'break', 'callable', 'case', 'catch', 'class',
+        'clone', 'const', 'continue', 'declare', 'default', 'die', 'do', 'echo', 'else', 'elseif',
+        'empty', 'enddeclare', 'endfor', 'endforeach', 'endif', 'endswitch', 'endwhile', 'enum',
+        'eval', 'exit', 'extends', 'false', 'final', 'finally', 'float', 'fn', 'for', 'foreach',
+        'function', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof',
+        'insteadof', 'int', 'interface', 'isset', 'iterable', 'list', 'match', 'mixed', 'namespace',
+        'never', 'new', 'null', 'object', 'or', 'parent', 'print', 'private', 'protected', 'public',
+        'readonly', 'require', 'require_once', 'return', 'self', 'static', 'string', 'switch',
+        'throw', 'trait', 'true', 'try', 'unset', 'use', 'var', 'void', 'while', 'xor', 'yield',
+    ];
+
     public function __construct(protected readonly Filesystem $files)
     {
         parent::__construct();
@@ -40,6 +59,12 @@ abstract class ScaffoldCommand extends Command
 
         if (! preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $studly)) {
             $this->components->error("The {$label} name must be a valid PHP identifier, [{$value}] is not.");
+
+            return null;
+        }
+
+        if (in_array(strtolower($studly), self::RESERVED, true)) {
+            $this->components->error("[{$studly}] is a PHP reserved word and cannot be used as a class name.");
 
             return null;
         }
@@ -109,7 +134,27 @@ abstract class ScaffoldCommand extends Command
         // preg_replace would read backslash sequences in the replacement as
         // backreferences, silently mangling namespaces such as \20.
         if ($matches[1] !== []) {
-            return preg_replace_callback('/^use .+;\n(use .+;\n)*/m', fn (): string => $block, $contents, 1);
+            // Every `use` line is collected above, so every one of them has to
+            // go: rewriting only the first contiguous run left the imports of
+            // any later group duplicated, and duplicate imports are fatal.
+            $written = false;
+
+            $result = preg_replace_callback(
+                '/^use .+;\n/m',
+                function () use ($block, &$written): string {
+                    if ($written) {
+                        return '';
+                    }
+
+                    $written = true;
+
+                    return $block;
+                },
+                $contents
+            );
+
+            // Collapse the blank lines left where a later group used to be.
+            return preg_replace("/\n{3,}/", "\n\n", (string) $result);
         }
 
         // No imports yet: open a block after the namespace declaration, or

--- a/app/Shared/SharedServiceProvider.php
+++ b/app/Shared/SharedServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Shared;
 
+use App\Shared\Infrastructure\Console\Commands\MakeAggregateCommand;
 use App\Shared\Infrastructure\Console\Commands\MakeBoundedContextCommand;
 use ComplexHeart\Domain\Contracts\Events\EventBus;
 use ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;
@@ -33,6 +34,7 @@ class SharedServiceProvider extends BoundedContextServiceProvider
     ];
 
     protected array $commands = [
+        MakeAggregateCommand::class,
         MakeBoundedContextCommand::class,
     ];
 

--- a/app/Shared/SharedServiceProvider.php
+++ b/app/Shared/SharedServiceProvider.php
@@ -101,7 +101,7 @@ class SharedServiceProvider extends BoundedContextServiceProvider
         RedirectResponse::macro('withErrorAlert', function (string $message, string $title = 'Oops...') {
             /** @var RedirectResponse $this */
             return $this->with('flash.alert', [
-                'style' => 'success',
+                'style' => 'danger',
                 'title' => $title,
                 'text' => $message,
             ]);

--- a/stubs/aggregate.api-controller.stub
+++ b/stubs/aggregate.api-controller.stub
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Infrastructure\Http\Controllers\API;
+
+use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Class {{ aggregate }}Controller
+ *
+ * @author {{ author }}
+ */
+class {{ aggregate }}Controller
+{
+    public function __construct(private readonly {{ aggregate }}Repository $repository) {}
+
+    public function index(): JsonResponse
+    {
+        return new JsonResponse($this->repository->match([]));
+    }
+}

--- a/stubs/aggregate.api-controller.stub
+++ b/stubs/aggregate.api-controller.stub
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\{{ context }}\{{ plural }}\Infrastructure\Http\Controllers\API;
 
 use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
-use App\{{ context }}\{{ plural }}\Domain\Exceptions\{{ aggregate }}NotFound;
 use Illuminate\Http\JsonResponse;
 
 /**
@@ -18,13 +17,10 @@ class {{ aggregate }}Controller
 {
     public function __construct(private readonly {{ aggregate }}Repository $repository) {}
 
-    /**
-     * @throws {{ aggregate }}NotFound
-     */
     public function show(string $id): JsonResponse
     {
-        return new JsonResponse(
-            $this->repository->find($id) ?? throw new {{ aggregate }}NotFound($id)
-        );
+        // abort() rather than the domain's NotFound: an unhandled domain
+        // exception would answer 500 to an ordinary missing record.
+        return new JsonResponse($this->repository->find($id) ?? abort(404));
     }
 }

--- a/stubs/aggregate.api-controller.stub
+++ b/stubs/aggregate.api-controller.stub
@@ -5,19 +5,26 @@ declare(strict_types=1);
 namespace App\{{ context }}\{{ plural }}\Infrastructure\Http\Controllers\API;
 
 use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
+use App\{{ context }}\{{ plural }}\Domain\Exceptions\{{ aggregate }}NotFound;
 use Illuminate\Http\JsonResponse;
 
 /**
  * Class {{ aggregate }}Controller
  *
- * @author {{ author }}
+ * A listing action is deliberately not scaffolded: the repository's match()
+ * returns every row, so decide how to bound it before adding one.
  */
 class {{ aggregate }}Controller
 {
     public function __construct(private readonly {{ aggregate }}Repository $repository) {}
 
-    public function index(): JsonResponse
+    /**
+     * @throws {{ aggregate }}NotFound
+     */
+    public function show(string $id): JsonResponse
     {
-        return new JsonResponse($this->repository->match([]));
+        return new JsonResponse(
+            $this->repository->find($id) ?? throw new {{ aggregate }}NotFound($id)
+        );
     }
 }

--- a/stubs/aggregate.eloquent-repository.stub
+++ b/stubs/aggregate.eloquent-repository.stub
@@ -10,8 +10,6 @@ use Illuminate\Support\Collection;
 
 /**
  * Class Eloquent{{ aggregate }}Repository
- *
- * @author {{ author }}
  */
 class Eloquent{{ aggregate }}Repository implements {{ aggregate }}Repository
 {

--- a/stubs/aggregate.eloquent-repository.stub
+++ b/stubs/aggregate.eloquent-repository.stub
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Infrastructure\Persistence;
+
+use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
+use App\{{ context }}\{{ plural }}\Domain\{{ aggregate }};
+use Illuminate\Support\Collection;
+
+/**
+ * Class Eloquent{{ aggregate }}Repository
+ *
+ * @author {{ author }}
+ */
+class Eloquent{{ aggregate }}Repository implements {{ aggregate }}Repository
+{
+    public function find(string $id): ?{{ aggregate }}
+    {
+        return {{ aggregate }}::find($id);
+    }
+
+    /**
+     * @param  array<string, mixed>  $criteria
+     * @return Collection<int, {{ aggregate }}>
+     */
+    public function match(array $criteria): Collection
+    {
+        return {{ aggregate }}::query()->where($criteria)->get();
+    }
+
+    public function save({{ aggregate }} ${{ variable }}): {{ aggregate }}
+    {
+        ${{ variable }}->save();
+
+        return ${{ variable }};
+    }
+
+    public function delete({{ aggregate }} ${{ variable }}): void
+    {
+        ${{ variable }}->delete();
+    }
+}

--- a/stubs/aggregate.event.stub
+++ b/stubs/aggregate.event.stub
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Domain\Events;
+
+use ComplexHeart\Domain\Contracts\Events\Event;
+use ComplexHeart\Domain\Events\IsDomainEvent;
+
+/**
+ * Class {{ aggregate }}Created
+ *
+ * @author {{ author }}
+ */
+final class {{ aggregate }}Created implements Event
+{
+    use IsDomainEvent;
+
+    /**
+     * @param  string  ${{ variable }}  The created {{ aggregate }} uuid
+     */
+    public function __construct(public string ${{ variable }}) {}
+}

--- a/stubs/aggregate.event.stub
+++ b/stubs/aggregate.event.stub
@@ -9,8 +9,6 @@ use ComplexHeart\Domain\Events\IsDomainEvent;
 
 /**
  * Class {{ aggregate }}Created
- *
- * @author {{ author }}
  */
 final class {{ aggregate }}Created implements Event
 {

--- a/stubs/aggregate.exception.stub
+++ b/stubs/aggregate.exception.stub
@@ -8,7 +8,5 @@ use Exception;
 
 /**
  * Class {{ aggregate }}Exception
- *
- * @author {{ author }}
  */
 class {{ aggregate }}Exception extends Exception {}

--- a/stubs/aggregate.exception.stub
+++ b/stubs/aggregate.exception.stub
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Domain\Exceptions;
+
+use Exception;
+
+/**
+ * Class {{ aggregate }}Exception
+ *
+ * @author {{ author }}
+ */
+class {{ aggregate }}Exception extends Exception {}

--- a/stubs/aggregate.factory.stub
+++ b/stubs/aggregate.factory.stub
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Infrastructure\Persistence;
+
+use App\{{ context }}\{{ plural }}\Domain\{{ aggregate }};
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<{{ aggregate }}>
+ */
+class {{ aggregate }}Factory extends Factory
+{
+    protected $model = {{ aggregate }}::class;
+
+    /**
+     * Build through the aggregate's own factory method, so seeded and tested
+     * instances get an identifier and record the same events as the ones the
+     * application layer creates.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function newModel(array $attributes = []): {{ aggregate }}
+    {
+        return {{ aggregate }}::new($attributes);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/stubs/aggregate.migration.stub
+++ b/stubs/aggregate.migration.stub
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('{{ table }}', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('{{ table }}');
+    }
+};

--- a/stubs/aggregate.model.stub
+++ b/stubs/aggregate.model.stub
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\{{ context }}\{{ plural }}\Domain;
+
+use App\Shared\Domain\HasDomainEvents;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+{{ modelUses }}
+/**
+ * Class {{ aggregate }}
+ *
+ * @property string $id
+ *
+ * @author {{ author }}
+ */
+class {{ aggregate }} extends Model
+{
+    use HasDomainEvents;
+{{ modelTraits }}    use HasUuids;
+
+    protected $table = '{{ table }}';
+
+    /** @var list<string> */
+    protected $fillable = [
+        //
+    ];
+
+    /**
+     * Creates a new {{ aggregate }}.
+     *
+     * The identifier is assigned up front, so domain events can carry it
+     * before the aggregate is persisted. Publishing them is the application
+     * layer's job.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public static function new(array $attributes = []): self
+    {
+        ${{ variable }} = new self(Arr::except($attributes, ['id']));
+        ${{ variable }}->id = $attributes['id'] ?? ${{ variable }}->newUniqueId();
+{{ modelRegisterEvent }}
+        return ${{ variable }};
+    }
+{{ modelFactoryMethod }}}

--- a/stubs/aggregate.model.stub
+++ b/stubs/aggregate.model.stub
@@ -11,8 +11,6 @@ use Illuminate\Support\Arr;
  * Class {{ aggregate }}
  *
  * @property string $id
- *
- * @author {{ author }}
  */
 class {{ aggregate }} extends Model
 {

--- a/stubs/aggregate.model.stub
+++ b/stubs/aggregate.model.stub
@@ -25,6 +25,18 @@ class {{ aggregate }} extends Model
     ];
 
     /**
+     * Attributes kept out of the model's array and JSON form.
+     *
+     * Worth filling in before anything serialises this: an API controller
+     * returning the model publishes every attribute it holds.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        //
+    ];
+
+    /**
      * Creates a new {{ aggregate }}.
      *
      * The identifier is assigned up front, so domain events can carry it

--- a/stubs/aggregate.not-found.stub
+++ b/stubs/aggregate.not-found.stub
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Domain\Exceptions;
+
+/**
+ * Class {{ aggregate }}NotFound
+ *
+ * @author {{ author }}
+ */
+class {{ aggregate }}NotFound extends {{ aggregate }}Exception {}

--- a/stubs/aggregate.not-found.stub
+++ b/stubs/aggregate.not-found.stub
@@ -6,7 +6,5 @@ namespace App\{{ context }}\{{ plural }}\Domain\Exceptions;
 
 /**
  * Class {{ aggregate }}NotFound
- *
- * @author {{ author }}
  */
 class {{ aggregate }}NotFound extends {{ aggregate }}Exception {}

--- a/stubs/aggregate.repository.stub
+++ b/stubs/aggregate.repository.stub
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Domain\Contracts;
+
+use App\{{ context }}\{{ plural }}\Domain\{{ aggregate }};
+use Illuminate\Support\Collection;
+
+interface {{ aggregate }}Repository
+{
+    public function find(string $id): ?{{ aggregate }};
+
+    /**
+     * @param  array<string, mixed>  $criteria
+     * @return Collection<int, {{ aggregate }}>
+     */
+    public function match(array $criteria): Collection;
+
+    public function save({{ aggregate }} ${{ variable }}): {{ aggregate }};
+
+    public function delete({{ aggregate }} ${{ variable }}): void;
+}

--- a/stubs/aggregate.request.stub
+++ b/stubs/aggregate.request.stub
@@ -8,8 +8,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 /**
  * Class Store{{ aggregate }}Request
- *
- * @author {{ author }}
  */
 class Store{{ aggregate }}Request extends FormRequest
 {

--- a/stubs/aggregate.request.stub
+++ b/stubs/aggregate.request.stub
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Infrastructure\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Class Store{{ aggregate }}Request
+ *
+ * @author {{ author }}
+ */
+class Store{{ aggregate }}Request extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/stubs/aggregate.web-controller.stub
+++ b/stubs/aggregate.web-controller.stub
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Infrastructure\Http\Controllers;
+
+use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
+use App\Shared\Infrastructure\Http\Controllers\InertiaController;
+use Illuminate\Http\Request;
+use Inertia\Response;
+
+/**
+ * Class {{ aggregate }}Controller
+ *
+ * Renders through InertiaController::render() rather than Inertia::render(),
+ * so the page goes through the rendering callbacks the base class exposes.
+ *
+ * @author {{ author }}
+ */
+class {{ aggregate }}Controller extends InertiaController
+{
+    public function __construct(private readonly {{ aggregate }}Repository $repository) {}
+
+    public function index(Request $request): Response
+    {
+        return $this->render($request, '{{ plural }}/Index', [
+            '{{ pluralVariable }}' => $this->repository->match([]),
+        ]);
+    }
+}

--- a/stubs/aggregate.web-controller.stub
+++ b/stubs/aggregate.web-controller.stub
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\{{ context }}\{{ plural }}\Infrastructure\Http\Controllers;
 
 use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
-use App\{{ context }}\{{ plural }}\Domain\Exceptions\{{ aggregate }}NotFound;
 use App\Shared\Infrastructure\Http\Controllers\InertiaController;
 use Illuminate\Http\Request;
 use Inertia\Response;
@@ -23,12 +22,12 @@ class {{ aggregate }}Controller extends InertiaController
 {
     public function __construct(private readonly {{ aggregate }}Repository $repository) {}
 
-    /**
-     * @throws {{ aggregate }}NotFound
-     */
     public function show(Request $request, string $id): Response
     {
-        ${{ variable }} = $this->repository->find($id) ?? throw new {{ aggregate }}NotFound($id);
+        // abort() rather than the domain's NotFound: mapping a domain
+        // exception to a status code is the HTTP layer's job, and an
+        // unhandled one would answer 500 to an ordinary missing record.
+        ${{ variable }} = $this->repository->find($id) ?? abort(404);
 
         return $this->render($request, '{{ plural }}/Show', [
             '{{ variable }}' => ${{ variable }},

--- a/stubs/aggregate.web-controller.stub
+++ b/stubs/aggregate.web-controller.stub
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\{{ context }}\{{ plural }}\Infrastructure\Http\Controllers;
 
 use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
+use App\{{ context }}\{{ plural }}\Domain\Exceptions\{{ aggregate }}NotFound;
 use App\Shared\Infrastructure\Http\Controllers\InertiaController;
 use Illuminate\Http\Request;
 use Inertia\Response;
@@ -15,16 +16,22 @@ use Inertia\Response;
  * Renders through InertiaController::render() rather than Inertia::render(),
  * so the page goes through the rendering callbacks the base class exposes.
  *
- * @author {{ author }}
+ * A listing action is deliberately not scaffolded: the repository's match()
+ * returns every row, so decide how to bound it before adding one.
  */
 class {{ aggregate }}Controller extends InertiaController
 {
     public function __construct(private readonly {{ aggregate }}Repository $repository) {}
 
-    public function index(Request $request): Response
+    /**
+     * @throws {{ aggregate }}NotFound
+     */
+    public function show(Request $request, string $id): Response
     {
-        return $this->render($request, '{{ plural }}/Index', [
-            '{{ pluralVariable }}' => $this->repository->match([]),
+        ${{ variable }} = $this->repository->find($id) ?? throw new {{ aggregate }}NotFound($id);
+
+        return $this->render($request, '{{ plural }}/Show', [
+            '{{ variable }}' => ${{ variable }},
         ]);
     }
 }

--- a/stubs/bounded-context.routes.api.stub
+++ b/stubs/bounded-context.routes.api.stub
@@ -4,12 +4,13 @@
 | API routes owned by the {{ context }} bounded context.
 |
 | Loaded by {{ context }}ServiceProvider through its $routes array. The api
-| middleware group is applied for you, but the URI prefix is not, so declare
-| it here:
+| middleware group is applied for you, but the URI prefix is not, so carry it
+| in the path — and keep it distinct from every web route, because two routes
+| sharing a method and a URI collapse into one:
 |
 |   use Illuminate\Support\Facades\Route;
 |
-|   Route::prefix('api')->middleware('auth:sanctum')->group(function () {
-|       Route::get('/example', ExampleController::class)->name('example');
+|   Route::middleware('auth:sanctum')->group(function () {
+|       Route::get('/api/example', ExampleController::class)->name('api.example');
 |   });
 */

--- a/stubs/bounded-context.routes.api.stub
+++ b/stubs/bounded-context.routes.api.stub
@@ -4,13 +4,13 @@
 | API routes owned by the {{ context }} bounded context.
 |
 | Loaded by {{ context }}ServiceProvider through its $routes array. The api
-| middleware group is applied for you, but the URI prefix is not, so carry it
-| in the path — and keep it distinct from every web route, because two routes
-| sharing a method and a URI collapse into one:
+| middleware group is applied for you, but the URI prefix is not, so declare
+| it here — and keep the result distinct from every web route, because two
+| routes sharing a method and a URI collapse into one:
 |
 |   use Illuminate\Support\Facades\Route;
 |
-|   Route::middleware('auth:sanctum')->group(function () {
-|       Route::get('/api/example', ExampleController::class)->name('api.example');
+|   Route::prefix('api')->middleware('auth:sanctum')->group(function () {
+|       Route::get('/example', ExampleController::class)->name('api.example');
 |   });
 */

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -287,6 +287,31 @@ test('it refuses an unknown bounded context', function () {
         ->assertFailed();
 });
 
+test('re-running with the same flags advises nothing', function () {
+    $args = ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true, '--factory' => true];
+
+    $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
+
+    // The model already carries both. Repeating the advice would redeclare
+    // newFactory(), which is fatal, and register the event a second time.
+    $this->artisan('ldd:make:aggregate', $args)
+        ->doesntExpectOutputToContain('Add to it by hand')
+        ->assertSuccessful();
+});
+
+test('it refuses a migration for a table the model does not declare', function () {
+    $args = ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true];
+
+    $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
+
+    // The model keeps pointing at widgets, so this migration would create a
+    // second table that nothing reads.
+    $this->artisan('ldd:make:aggregate', $args + ['--table' => 'renamed'])->assertFailed();
+
+    expect(File::glob(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/Migrations/*.php')))
+        ->toHaveCount(1);
+});
+
 test('re-running adds the missing piece without touching the model', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertSuccessful();
 

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -14,9 +14,11 @@ beforeEach(function () {
     $this->providers = base_path('bootstrap/providers.php');
     $this->providersBackup = File::get($this->providers);
 
-    expect(app_path('ScaffoldFixture'))->not->toBeDirectory(
-        'app/ScaffoldFixture already exists; refusing to run so the teardown cannot delete it.'
-    );
+    foreach (['ScaffoldFixture', 'ScaffoldOther'] as $fixture) {
+        expect(app_path($fixture))->not->toBeDirectory(
+            "app/{$fixture} already exists; refusing to run so the teardown cannot delete it."
+        );
+    }
 
     $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
     $this->createdFixture = true;
@@ -25,8 +27,12 @@ beforeEach(function () {
 afterEach(function () {
     File::put($this->providers, $this->providersBackup);
 
+    // Both fixtures are removed here rather than in the test body: an
+    // assertion that fails leaves whatever the body had not reached yet, and
+    // a leaked context makes every later run of the suite fail too.
     if ($this->createdFixture ?? false) {
         File::deleteDirectory(app_path('ScaffoldFixture'));
+        File::deleteDirectory(app_path('ScaffoldOther'));
     }
 });
 
@@ -192,8 +198,16 @@ test('it refuses a table another context already creates', function () {
     $this->artisan('ldd:make:aggregate', [
         'context' => 'ScaffoldOther', 'name' => 'Widget', '--migration' => true, '--table' => 'other_widgets',
     ])->assertSuccessful();
+});
 
-    File::deleteDirectory(app_path('ScaffoldOther'));
+test('it refuses a table name that is not a valid identifier', function () {
+    $this->artisan('ldd:make:aggregate', [
+        'context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true, '--table' => "odd'name",
+    ])->assertFailed();
+
+    // The name reaches both the model's $table property and Schema::create(),
+    // so an unchecked quote ships two files that do not parse.
+    expect(app_path('ScaffoldFixture/Widgets'))->not->toBeDirectory();
 });
 
 test('it does not bind twice when the provider was reformatted', function () {
@@ -265,6 +279,42 @@ test('it refuses an unknown bounded context', function () {
 test('it refuses to overwrite an existing aggregate', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertSuccessful();
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertFailed();
+});
+
+test('it hints a distinct route name for the api controller', function () {
+    // A route name is global: sharing one leaves route() resolving to
+    // whichever file was loaded first, with no error either way.
+    $this->artisan('ldd:make:aggregate', [
+        'context' => 'ScaffoldFixture', 'name' => 'Widget', '--web' => true, '--api' => true,
+    ])
+        ->expectsOutputToContain("->name('widgets.show')")
+        ->expectsOutputToContain("->name('api.widgets.show')")
+        ->assertSuccessful();
+});
+
+test('it warns when the route file the hint points at does not exist', function () {
+    // The fixture context was created without --web, so following the hint
+    // literally yields a route file nothing loads and a silent 404.
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--web' => true])
+        ->expectsOutputToContain('That file does not exist yet')
+        ->assertSuccessful();
+});
+
+test('everything it generates parses', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--all' => true])
+        ->assertSuccessful();
+
+    // The fixture is deleted in teardown, so CI's Pint, PHPStan and arch legs
+    // never see the generated code. Without this, a typo in any stub ships
+    // green: every other test asserts on substrings and file existence.
+    $files = File::allFiles(app_path('ScaffoldFixture'));
+
+    expect($files)->not->toBeEmpty();
+
+    foreach ($files as $file) {
+        expect(php_parses($file->getPathname()))
+            ->toBeTrue("{$file->getRelativePathname()} does not parse");
+    }
 });
 
 test('all generates every optional piece', function () {

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -281,15 +281,34 @@ test('it refuses to overwrite an existing aggregate', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertFailed();
 });
 
-test('it hints a distinct route name for the api controller', function () {
-    // A route name is global: sharing one leaves route() resolving to
-    // whichever file was loaded first, with no error either way.
+test('it hints a distinct route for the api controller', function () {
+    // Sharing a URI does not add a second route: RouteCollection keys by
+    // method and URI, so the api route would replace the web one and take
+    // its name with it. Sharing a name resolves route() to whichever came
+    // first. Both have to differ.
     $this->artisan('ldd:make:aggregate', [
         'context' => 'ScaffoldFixture', 'name' => 'Widget', '--web' => true, '--api' => true,
     ])
-        ->expectsOutputToContain("->name('widgets.show')")
-        ->expectsOutputToContain("->name('api.widgets.show')")
+        // One expectation per emitted line: each is consumed as it matches,
+        // so URI and name go in the same assertion rather than two.
+        ->expectsOutputToContain("Route::get('/widgets/{id}', [WidgetController::class, 'show'])->name('widgets.show');")
+        ->expectsOutputToContain("Route::get('/api/widgets/{id}', [WidgetController::class, 'show'])->name('api.widgets.show');")
         ->assertSuccessful();
+});
+
+test('it fails when the context provider has nothing to wire', function () {
+    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+
+    File::put($provider, "<?php\n\nnamespace App\ScaffoldFixture;\n\nuse ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;\n\nclass ScaffoldFixtureServiceProvider extends BoundedContextServiceProvider\n{\n}\n");
+
+    // Reporting success would leave an aggregate whose repository contract
+    // resolves to nothing — the whole point of the wiring step.
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
+        ->assertFailed();
+
+    // A provider it could not wire must be left exactly as it was, not
+    // carrying imports for a binding that never landed.
+    expect(File::get($provider))->not->toContain('WidgetRepository');
 });
 
 test('it warns when the route file the hint points at does not exist', function () {

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -129,6 +129,92 @@ test('it refuses names that are not valid PHP identifiers', function () {
         ->not->toContain('2024');
 });
 
+test('it refuses PHP reserved words as aggregate names', function () {
+    foreach (['Case', 'Match', 'List'] as $reserved) {
+        $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => $reserved])
+            ->assertFailed();
+    }
+
+    expect(app_path('ScaffoldFixture/Cases'))->not->toBeDirectory();
+});
+
+test('it takes the aggregate name as written', function () {
+    // Singularising unconditionally turns Analysis into Analysi.
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Analysis'])
+        ->assertSuccessful();
+
+    expect(app_path('ScaffoldFixture/Analyses/Domain/Analysis.php'))->toBeFile();
+});
+
+test('it wires a provider whose array holds only a comment', function () {
+    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+
+    File::put($provider, str_replace(
+        'public array $bindings = [];',
+        'public array $bindings = [/* add bindings here */];',
+        File::get($provider)
+    ));
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
+        ->assertSuccessful();
+
+    // A comment is not an element: emitting it as one produces `[,` and a
+    // provider that does not parse, while the command reports success.
+    expect(php_parses($provider))->toBeTrue();
+});
+
+test('it does not duplicate imports when the provider has several groups', function () {
+    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+
+    File::put($provider, str_replace(
+        'use ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;',
+        "use ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;\n\n// the developer's own group\nuse Illuminate\Support\Str;",
+        File::get($provider)
+    ));
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
+        ->assertSuccessful();
+
+    expect(substr_count(File::get($provider), 'use Illuminate\Support\Str;'))->toBe(1)
+        ->and(php_parses($provider))->toBeTrue();
+});
+
+test('it refuses a table another context already creates', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true])
+        ->assertSuccessful();
+
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldOther'])->assertSuccessful();
+
+    // Both would Schema::create('widgets') and abort migrate on a fresh database.
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldOther', 'name' => 'Widget', '--migration' => true])
+        ->assertFailed();
+
+    $this->artisan('ldd:make:aggregate', [
+        'context' => 'ScaffoldOther', 'name' => 'Widget', '--migration' => true, '--table' => 'other_widgets',
+    ])->assertSuccessful();
+
+    File::deleteDirectory(app_path('ScaffoldOther'));
+});
+
+test('it does not bind twice when the provider was reformatted', function () {
+    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertSuccessful();
+
+    File::put($provider, str_replace(
+        '        WidgetRepository::class => EloquentWidgetRepository::class,',
+        '            WidgetRepository::class   => EloquentWidgetRepository::class,',
+        File::get($provider)
+    ));
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--force' => true])
+        ->assertSuccessful();
+
+    // EloquentWidgetRepository::class contains WidgetRepository::class, so
+    // count the mapping rather than the bare class reference.
+    expect(substr_count(File::get($provider), '=> EloquentWidgetRepository::class'))->toBe(1);
+});
+
 test('it refuses to scaffold into the Shared foundation layer', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'Shared', 'name' => 'Widget'])
         ->assertFailed();
@@ -164,8 +250,8 @@ test('it wires a provider whose arrays are declared inline', function () {
         ->toContain('WidgetRepository::class => EloquentWidgetRepository::class,');
 });
 
-test('it pluralises the aggregate directory and singularises the class', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'widgets'])
+test('it pluralises the aggregate directory and studlies the class', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'widget'])
         ->assertSuccessful();
 
     expect(app_path('ScaffoldFixture/Widgets/Domain/Widget.php'))->toBeFile();

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -299,6 +299,29 @@ test('it refuses an unknown bounded context', function () {
         ->assertFailed();
 });
 
+test('it says that nothing publishes the generated event', function () {
+    // The aggregate records the event; only a use case publishes it. Without
+    // one the events pile up on the instance and vanish with it, which is the
+    // silent failure these commands exist to prevent.
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
+        ->expectsOutputToContain('Nothing publishes WidgetCreated.')
+        ->expectsOutputToContain('publishDomainEvents($this->eventBus)')
+        ->assertSuccessful();
+});
+
+test('it stays quiet when the application layer already publishes', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
+        ->assertSuccessful();
+
+    $application = app_path('ScaffoldFixture/Widgets/Application');
+    File::ensureDirectoryExists($application);
+    File::put("{$application}/CreateWidget.php", "<?php\n\n// \$widget->publishDomainEvents(\$this->eventBus);\n");
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
+        ->doesntExpectOutputToContain('Nothing publishes WidgetCreated.')
+        ->assertSuccessful();
+});
+
 test('it does not re-advise a route the file already declares', function () {
     $args = ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--web' => true];
 

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -299,6 +299,17 @@ test('it refuses an unknown bounded context', function () {
         ->assertFailed();
 });
 
+test('the generated model has a place to hide attributes', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--api' => true])
+        ->assertSuccessful();
+
+    // The API controller returns the model straight into a JsonResponse, so
+    // whatever reaches $fillable is published unless $hidden says otherwise.
+    // Anchored to a real property, not a mention in a comment.
+    expect(File::get(app_path('ScaffoldFixture/Widgets/Domain/Widget.php')))
+        ->toMatch('/^    protected \$hidden = \[/m');
+});
+
 test('it says that nothing publishes the generated event', function () {
     // The aggregate records the event; only a use case publishes it. Without
     // one the events pile up on the instance and vanish with it, which is the

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -221,7 +221,7 @@ test('it does not bind twice when the provider was reformatted', function () {
         File::get($provider)
     ));
 
-    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--force' => true])
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
         ->assertSuccessful();
 
     // EloquentWidgetRepository::class contains WidgetRepository::class, so
@@ -240,11 +240,22 @@ test('it reuses the migration filename instead of duplicating it', function () {
     $args = ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true];
 
     $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
-    $this->artisan('ldd:make:aggregate', $args + ['--force' => true])->assertSuccessful();
 
-    // Two create-table migrations would abort `migrate` on a fresh database.
+    $migration = File::glob(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/Migrations/*_create_widgets_table.php'))[0];
+    File::put($migration, str_replace(
+        '$table->timestamps();',
+        "\$table->string('reference')->unique();\n            \$table->timestamps();",
+        File::get($migration)
+    ));
+
+    $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
+
+    // Two create-table migrations would abort `migrate` on a fresh database,
+    // and rewriting the one that is there loses schema that may already have
+    // been applied: Laravel records it as run by filename, so it never replays.
     expect(File::glob(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/Migrations/*_create_widgets_table.php')))
-        ->toHaveCount(1);
+        ->toHaveCount(1)
+        ->and(File::get($migration))->toContain("\$table->string('reference')->unique();");
 });
 
 test('it wires a provider whose arrays are declared inline', function () {
@@ -276,9 +287,21 @@ test('it refuses an unknown bounded context', function () {
         ->assertFailed();
 });
 
-test('it refuses to overwrite an existing aggregate', function () {
+test('re-running adds the missing piece without touching the model', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertSuccessful();
-    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertFailed();
+
+    $model = app_path('ScaffoldFixture/Widgets/Domain/Widget.php');
+    File::put($model, str_replace("        //\n    ];", "        'reference',\n    ];", File::get($model)));
+
+    // Adding an option you skipped is the reason to run this twice, and the
+    // model is where hand-written work accumulates.
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
+        ->expectsOutputToContain('Widget was left as it is. Add to it by hand:')
+        ->assertSuccessful();
+
+    expect(app_path('ScaffoldFixture/Widgets/Domain/Events/WidgetCreated.php'))->toBeFile()
+        ->and(File::get($model))->toContain("'reference',")
+        ->and(File::get($model))->not->toContain('registerDomainEvent');
 });
 
 test('it hints a distinct route for the api controller', function () {

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -20,12 +20,24 @@ beforeEach(function () {
         );
     }
 
+    // Lives outside app/, so it needs the same guard: the suite refuses to
+    // run rather than risk deleting a page directory it did not create.
+    $this->pages = base_path('resources/templates/tailwindcss/js/Pages/Widgets');
+
+    expect($this->pages)->not->toBeDirectory(
+        "{$this->pages} already exists; refusing to run so the teardown cannot delete it."
+    );
+
     $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
     $this->createdFixture = true;
 });
 
 afterEach(function () {
     File::put($this->providers, $this->providersBackup);
+
+    if ($this->createdFixture ?? false) {
+        File::deleteDirectory($this->pages);
+    }
 
     // Both fixtures are removed here rather than in the test body: an
     // assertion that fails leaves whatever the body had not reached yet, and
@@ -285,6 +297,32 @@ test('it pluralises the aggregate directory and studlies the class', function ()
 test('it refuses an unknown bounded context', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'Nope', 'name' => 'Widget'])
         ->assertFailed();
+});
+
+test('it does not re-advise a route the file already declares', function () {
+    $args = ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--web' => true];
+
+    $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
+
+    $routes = app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes');
+    File::ensureDirectoryExists($routes);
+    File::put("{$routes}/web.php", "<?php\n\nRoute::middleware('auth')->get('/widgets/{id}', [WidgetController::class, 'show'])->name('widgets.show');\n");
+
+    // Pasting the canonical route back replaces the customised one, since
+    // RouteCollection keys by method and URI, and the auth middleware is
+    // gone with no error anywhere.
+    $this->artisan('ldd:make:aggregate', $args)
+        ->doesntExpectOutputToContain("->name('widgets.show')")
+        ->assertSuccessful();
+});
+
+test('it does not advise creating a page that already exists', function () {
+    File::ensureDirectoryExists($this->pages);
+    File::put("{$this->pages}/Show.vue", '<template><div /></template>');
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--web' => true])
+        ->doesntExpectOutputToContain('Create the page at')
+        ->assertSuccessful();
 });
 
 test('re-running with the same flags advises nothing', function () {

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+/*
+ * The command writes into app/ and edits the context provider, so every test
+ * starts from a freshly generated context and removes it afterwards.
+ */
+beforeEach(function () {
+    $this->providers = base_path('bootstrap/providers.php');
+    $this->providersBackup = File::get($this->providers);
+
+    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing'])->assertSuccessful();
+});
+
+afterEach(function () {
+    File::put($this->providers, $this->providersBackup);
+    File::deleteDirectory(app_path('Billing'));
+});
+
+test('it generates only the core by default', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])
+        ->assertSuccessful();
+
+    expect(app_path('Billing/Invoices/Domain/Invoice.php'))->toBeFile()
+        ->and(app_path('Billing/Invoices/Domain/Contracts/InvoiceRepository.php'))->toBeFile()
+        ->and(app_path('Billing/Invoices/Domain/Exceptions/InvoiceNotFound.php'))->toBeFile()
+        ->and(app_path('Billing/Invoices/Infrastructure/Persistence/EloquentInvoiceRepository.php'))->toBeFile();
+
+    expect(app_path('Billing/Invoices/Domain/Events'))->not->toBeDirectory()
+        ->and(app_path('Billing/Invoices/Infrastructure/Persistence/Migrations'))->not->toBeDirectory()
+        ->and(app_path('Billing/Invoices/Infrastructure/Http'))->not->toBeDirectory();
+});
+
+test('it binds the repository in the context provider', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])
+        ->assertSuccessful();
+
+    expect(File::get(app_path('Billing/BillingServiceProvider.php')))
+        ->toContain('use App\Billing\Invoices\Domain\Contracts\InvoiceRepository;')
+        ->toContain('use App\Billing\Invoices\Infrastructure\Persistence\EloquentInvoiceRepository;')
+        ->toContain('InvoiceRepository::class => EloquentInvoiceRepository::class,');
+});
+
+test('it registers the migration path only when a migration is generated', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])->assertSuccessful();
+
+    expect(File::get(app_path('Billing/BillingServiceProvider.php')))
+        ->not->toContain('Invoices/Infrastructure/Persistence/Migrations');
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Receipt', '--migration' => true])
+        ->assertSuccessful();
+
+    expect(File::get(app_path('Billing/BillingServiceProvider.php')))
+        ->toContain("__DIR__.'/Receipts/Infrastructure/Persistence/Migrations',");
+});
+
+test('the aggregate records its creation only with the events flag', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])->assertSuccessful();
+    expect(File::get(app_path('Billing/Invoices/Domain/Invoice.php')))
+        ->not->toContain('registerDomainEvent');
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Receipt', '--events' => true])
+        ->assertSuccessful();
+
+    expect(app_path('Billing/Receipts/Domain/Events/ReceiptCreated.php'))->toBeFile();
+    expect(File::get(app_path('Billing/Receipts/Domain/Receipt.php')))
+        ->toContain('registerDomainEvent(ReceiptCreated::new($receipt->id))');
+});
+
+test('the factory is routed through the aggregate factory method', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice', '--factory' => true])
+        ->assertSuccessful();
+
+    expect(File::get(app_path('Billing/Invoices/Infrastructure/Persistence/InvoiceFactory.php')))
+        ->toContain('return Invoice::new($attributes);');
+
+    // Laravel would not find a factory outside Database\Factories, so the
+    // model has to point at it explicitly.
+    expect(File::get(app_path('Billing/Invoices/Domain/Invoice.php')))
+        ->toContain('protected static function newFactory(): InvoiceFactory');
+});
+
+test('it pluralises the aggregate directory and singularises the class', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'invoices'])
+        ->assertSuccessful();
+
+    expect(app_path('Billing/Invoices/Domain/Invoice.php'))->toBeFile();
+});
+
+test('it refuses an unknown bounded context', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Nope', 'name' => 'Invoice'])
+        ->assertFailed();
+});
+
+test('it refuses to overwrite an existing aggregate', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])->assertSuccessful();
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])->assertFailed();
+});
+
+test('all generates every optional piece', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice', '--all' => true])
+        ->assertSuccessful();
+
+    expect(app_path('Billing/Invoices/Domain/Events/InvoiceCreated.php'))->toBeFile()
+        ->and(app_path('Billing/Invoices/Infrastructure/Persistence/InvoiceFactory.php'))->toBeFile()
+        ->and(app_path('Billing/Invoices/Infrastructure/Http/Requests/StoreInvoiceRequest.php'))->toBeFile()
+        ->and(app_path('Billing/Invoices/Infrastructure/Http/Controllers/API/InvoiceController.php'))->toBeFile()
+        ->and(File::glob(app_path('Billing/Invoices/Infrastructure/Persistence/Migrations/*_create_invoices_table.php')))
+        ->toHaveCount(1);
+});

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -5,122 +5,191 @@ use Illuminate\Support\Facades\File;
 /*
  * The command writes into app/ and edits the context provider, so every test
  * starts from a freshly generated context and removes it afterwards.
+ *
+ * The teardown only ever deletes a directory this file created: in a starter
+ * kit these tests run inside somebody else's application, and a fixture name
+ * that happened to collide would otherwise take their context with it.
  */
 beforeEach(function () {
     $this->providers = base_path('bootstrap/providers.php');
     $this->providersBackup = File::get($this->providers);
 
-    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing'])->assertSuccessful();
+    expect(app_path('ScaffoldFixture'))->not->toBeDirectory(
+        'app/ScaffoldFixture already exists; refusing to run so the teardown cannot delete it.'
+    );
+
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->createdFixture = true;
 });
 
 afterEach(function () {
     File::put($this->providers, $this->providersBackup);
-    File::deleteDirectory(app_path('Billing'));
+
+    if ($this->createdFixture ?? false) {
+        File::deleteDirectory(app_path('ScaffoldFixture'));
+    }
 });
 
 test('it generates only the core by default', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
         ->assertSuccessful();
 
-    expect(app_path('Billing/Invoices/Domain/Invoice.php'))->toBeFile()
-        ->and(app_path('Billing/Invoices/Domain/Contracts/InvoiceRepository.php'))->toBeFile()
-        ->and(app_path('Billing/Invoices/Domain/Exceptions/InvoiceNotFound.php'))->toBeFile()
-        ->and(app_path('Billing/Invoices/Infrastructure/Persistence/EloquentInvoiceRepository.php'))->toBeFile();
+    expect(app_path('ScaffoldFixture/Widgets/Domain/Widget.php'))->toBeFile()
+        ->and(app_path('ScaffoldFixture/Widgets/Domain/Contracts/WidgetRepository.php'))->toBeFile()
+        ->and(app_path('ScaffoldFixture/Widgets/Domain/Exceptions/WidgetNotFound.php'))->toBeFile()
+        ->and(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/EloquentWidgetRepository.php'))->toBeFile();
 
-    expect(app_path('Billing/Invoices/Domain/Events'))->not->toBeDirectory()
-        ->and(app_path('Billing/Invoices/Infrastructure/Persistence/Migrations'))->not->toBeDirectory()
-        ->and(app_path('Billing/Invoices/Infrastructure/Http'))->not->toBeDirectory();
+    expect(app_path('ScaffoldFixture/Widgets/Domain/Events'))->not->toBeDirectory()
+        ->and(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/Migrations'))->not->toBeDirectory()
+        ->and(app_path('ScaffoldFixture/Widgets/Infrastructure/Http'))->not->toBeDirectory();
 });
 
 test('it binds the repository in the context provider', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
         ->assertSuccessful();
 
-    expect(File::get(app_path('Billing/BillingServiceProvider.php')))
-        ->toContain('use App\Billing\Invoices\Domain\Contracts\InvoiceRepository;')
-        ->toContain('use App\Billing\Invoices\Infrastructure\Persistence\EloquentInvoiceRepository;')
-        ->toContain('InvoiceRepository::class => EloquentInvoiceRepository::class,');
+    expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
+        ->toContain('use App\ScaffoldFixture\Widgets\Domain\Contracts\WidgetRepository;')
+        ->toContain('use App\ScaffoldFixture\Widgets\Infrastructure\Persistence\EloquentWidgetRepository;')
+        ->toContain('WidgetRepository::class => EloquentWidgetRepository::class,');
 });
 
 test('it registers the migration path only when a migration is generated', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])->assertSuccessful();
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertSuccessful();
 
-    expect(File::get(app_path('Billing/BillingServiceProvider.php')))
-        ->not->toContain('Invoices/Infrastructure/Persistence/Migrations');
+    expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
+        ->not->toContain('Widgets/Infrastructure/Persistence/Migrations');
 
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Receipt', '--migration' => true])
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Gadget', '--migration' => true])
         ->assertSuccessful();
 
-    expect(File::get(app_path('Billing/BillingServiceProvider.php')))
-        ->toContain("__DIR__.'/Receipts/Infrastructure/Persistence/Migrations',");
+    expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
+        ->toContain("__DIR__.'/Gadgets/Infrastructure/Persistence/Migrations',");
 });
 
 test('the aggregate records its creation only with the events flag', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])->assertSuccessful();
-    expect(File::get(app_path('Billing/Invoices/Domain/Invoice.php')))
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertSuccessful();
+    expect(File::get(app_path('ScaffoldFixture/Widgets/Domain/Widget.php')))
         ->not->toContain('registerDomainEvent');
 
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Receipt', '--events' => true])
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Gadget', '--events' => true])
         ->assertSuccessful();
 
-    expect(app_path('Billing/Receipts/Domain/Events/ReceiptCreated.php'))->toBeFile();
-    expect(File::get(app_path('Billing/Receipts/Domain/Receipt.php')))
-        ->toContain('registerDomainEvent(ReceiptCreated::new($receipt->id))');
+    expect(app_path('ScaffoldFixture/Gadgets/Domain/Events/GadgetCreated.php'))->toBeFile();
+    expect(File::get(app_path('ScaffoldFixture/Gadgets/Domain/Gadget.php')))
+        ->toContain('registerDomainEvent(GadgetCreated::new($gadget->id))');
 });
 
 test('the factory is routed through the aggregate factory method', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice', '--factory' => true])
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--factory' => true])
         ->assertSuccessful();
 
-    expect(File::get(app_path('Billing/Invoices/Infrastructure/Persistence/InvoiceFactory.php')))
-        ->toContain('return Invoice::new($attributes);');
+    expect(File::get(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/WidgetFactory.php')))
+        ->toContain('return Widget::new($attributes);');
 
     // Laravel would not find a factory outside Database\Factories, so the
     // model has to point at it explicitly.
-    expect(File::get(app_path('Billing/Invoices/Domain/Invoice.php')))
-        ->toContain('protected static function newFactory(): InvoiceFactory');
+    expect(File::get(app_path('ScaffoldFixture/Widgets/Domain/Widget.php')))
+        ->toContain('protected static function newFactory(): WidgetFactory');
 });
 
 test('the web flag generates an Inertia controller', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice', '--web' => true])
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--web' => true])
         ->assertSuccessful();
 
     // Rendering goes through the shared base, not Inertia::render directly,
     // so the page passes through its rendering callbacks.
-    expect(File::get(app_path('Billing/Invoices/Infrastructure/Http/Controllers/InvoiceController.php')))
+    expect(File::get(app_path('ScaffoldFixture/Widgets/Infrastructure/Http/Controllers/WidgetController.php')))
         ->toContain('extends InertiaController')
-        ->toContain("\$this->render(\$request, 'Invoices/Index'");
+        ->toContain("\$this->render(\$request, 'Widgets/Show'");
 
-    expect(app_path('Billing/Invoices/Infrastructure/Http/Controllers/API/InvoiceController.php'))
+    expect(app_path('ScaffoldFixture/Widgets/Infrastructure/Http/Controllers/API/WidgetController.php'))
         ->not->toBeFile();
 });
 
-test('it pluralises the aggregate directory and singularises the class', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'invoices'])
+test('generated controllers do not ship an unbounded read', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--web' => true, '--api' => true])
         ->assertSuccessful();
 
-    expect(app_path('Billing/Invoices/Domain/Invoice.php'))->toBeFile();
+    foreach (['Controllers/WidgetController.php', 'Controllers/API/WidgetController.php'] as $controller) {
+        expect(File::get(app_path("ScaffoldFixture/Widgets/Infrastructure/Http/{$controller}")))
+            ->not->toContain('match([])');
+    }
+});
+
+test('it refuses names that are not valid PHP identifiers', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => '2024Report'])
+        ->assertFailed();
+
+    expect(app_path('ScaffoldFixture/2024Reports'))->not->toBeDirectory();
+
+    // The provider must be untouched: a mangled binding there takes the whole
+    // application down, not just the generated aggregate.
+    expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
+        ->not->toContain('2024');
+});
+
+test('it refuses to scaffold into the Shared foundation layer', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Shared', 'name' => 'Widget'])
+        ->assertFailed();
+
+    expect(app_path('Shared/Widgets'))->not->toBeDirectory();
+});
+
+test('it reuses the migration filename instead of duplicating it', function () {
+    $args = ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true];
+
+    $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
+    $this->artisan('ldd:make:aggregate', $args + ['--force' => true])->assertSuccessful();
+
+    // Two create-table migrations would abort `migrate` on a fresh database.
+    expect(File::glob(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/Migrations/*_create_widgets_table.php')))
+        ->toHaveCount(1);
+});
+
+test('it wires a provider whose arrays are declared inline', function () {
+    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+
+    File::put($provider, str_replace(
+        'public array $bindings = [];',
+        'public array $bindings = [FooRepository::class => EloquentFooRepository::class];',
+        File::get($provider)
+    ));
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
+        ->assertSuccessful();
+
+    expect(File::get($provider))
+        ->toContain('FooRepository::class => EloquentFooRepository::class,')
+        ->toContain('WidgetRepository::class => EloquentWidgetRepository::class,');
+});
+
+test('it pluralises the aggregate directory and singularises the class', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'widgets'])
+        ->assertSuccessful();
+
+    expect(app_path('ScaffoldFixture/Widgets/Domain/Widget.php'))->toBeFile();
 });
 
 test('it refuses an unknown bounded context', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'Nope', 'name' => 'Invoice'])
+    $this->artisan('ldd:make:aggregate', ['context' => 'Nope', 'name' => 'Widget'])
         ->assertFailed();
 });
 
 test('it refuses to overwrite an existing aggregate', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])->assertSuccessful();
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice'])->assertFailed();
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertSuccessful();
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertFailed();
 });
 
 test('all generates every optional piece', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice', '--all' => true])
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--all' => true])
         ->assertSuccessful();
 
-    expect(app_path('Billing/Invoices/Domain/Events/InvoiceCreated.php'))->toBeFile()
-        ->and(app_path('Billing/Invoices/Infrastructure/Persistence/InvoiceFactory.php'))->toBeFile()
-        ->and(app_path('Billing/Invoices/Infrastructure/Http/Requests/StoreInvoiceRequest.php'))->toBeFile()
-        ->and(app_path('Billing/Invoices/Infrastructure/Http/Controllers/InvoiceController.php'))->toBeFile()
-        ->and(app_path('Billing/Invoices/Infrastructure/Http/Controllers/API/InvoiceController.php'))->toBeFile()
-        ->and(File::glob(app_path('Billing/Invoices/Infrastructure/Persistence/Migrations/*_create_invoices_table.php')))
+    expect(app_path('ScaffoldFixture/Widgets/Domain/Events/WidgetCreated.php'))->toBeFile()
+        ->and(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/WidgetFactory.php'))->toBeFile()
+        ->and(app_path('ScaffoldFixture/Widgets/Infrastructure/Http/Requests/StoreWidgetRequest.php'))->toBeFile()
+        ->and(app_path('ScaffoldFixture/Widgets/Infrastructure/Http/Controllers/WidgetController.php'))->toBeFile()
+        ->and(app_path('ScaffoldFixture/Widgets/Infrastructure/Http/Controllers/API/WidgetController.php'))->toBeFile()
+        ->and(File::glob(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/Migrations/*_create_widgets_table.php')))
         ->toHaveCount(1);
 });

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -290,9 +290,12 @@ test('it hints a distinct route for the api controller', function () {
         'context' => 'ScaffoldFixture', 'name' => 'Widget', '--web' => true, '--api' => true,
     ])
         // One expectation per emitted line: each is consumed as it matches,
-        // so URI and name go in the same assertion rather than two.
+        // so URI and name go in the same assertion rather than two. The api
+        // URI is kept apart by the prefix group, the convention the rest of
+        // the application already follows.
         ->expectsOutputToContain("Route::get('/widgets/{id}', [WidgetController::class, 'show'])->name('widgets.show');")
-        ->expectsOutputToContain("Route::get('/api/widgets/{id}', [WidgetController::class, 'show'])->name('api.widgets.show');")
+        ->expectsOutputToContain("Route::prefix('api')->group(function () {")
+        ->expectsOutputToContain("Route::get('/widgets/{id}', [WidgetController::class, 'show'])->name('api.widgets.show');")
         ->assertSuccessful();
 });
 

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -81,6 +81,20 @@ test('the factory is routed through the aggregate factory method', function () {
         ->toContain('protected static function newFactory(): InvoiceFactory');
 });
 
+test('the web flag generates an Inertia controller', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'Invoice', '--web' => true])
+        ->assertSuccessful();
+
+    // Rendering goes through the shared base, not Inertia::render directly,
+    // so the page passes through its rendering callbacks.
+    expect(File::get(app_path('Billing/Invoices/Infrastructure/Http/Controllers/InvoiceController.php')))
+        ->toContain('extends InertiaController')
+        ->toContain("\$this->render(\$request, 'Invoices/Index'");
+
+    expect(app_path('Billing/Invoices/Infrastructure/Http/Controllers/API/InvoiceController.php'))
+        ->not->toBeFile();
+});
+
 test('it pluralises the aggregate directory and singularises the class', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'Billing', 'name' => 'invoices'])
         ->assertSuccessful();
@@ -105,6 +119,7 @@ test('all generates every optional piece', function () {
     expect(app_path('Billing/Invoices/Domain/Events/InvoiceCreated.php'))->toBeFile()
         ->and(app_path('Billing/Invoices/Infrastructure/Persistence/InvoiceFactory.php'))->toBeFile()
         ->and(app_path('Billing/Invoices/Infrastructure/Http/Requests/StoreInvoiceRequest.php'))->toBeFile()
+        ->and(app_path('Billing/Invoices/Infrastructure/Http/Controllers/InvoiceController.php'))->toBeFile()
         ->and(app_path('Billing/Invoices/Infrastructure/Http/Controllers/API/InvoiceController.php'))->toBeFile()
         ->and(File::glob(app_path('Billing/Invoices/Infrastructure/Persistence/Migrations/*_create_invoices_table.php')))
         ->toHaveCount(1);

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -14,24 +14,24 @@ beforeEach(function () {
 afterEach(function () {
     File::put($this->providers, $this->providersBackup);
 
-    foreach (['Billing', 'Reporting'] as $context) {
+    foreach (['ScaffoldFixture', 'Reporting'] as $context) {
         File::deleteDirectory(app_path($context));
     }
 });
 
 test('it scaffolds the context and registers its provider', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing'])
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])
         ->assertSuccessful();
 
-    expect(app_path('Billing/BillingServiceProvider.php'))->toBeFile();
+    expect(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php'))->toBeFile();
 
     expect(File::get($this->providers))
-        ->toContain('use App\Billing\BillingServiceProvider;')
-        ->toContain('BillingServiceProvider::class,');
+        ->toContain('use App\ScaffoldFixture\ScaffoldFixtureServiceProvider;')
+        ->toContain('ScaffoldFixtureServiceProvider::class,');
 });
 
 test('it keeps the provider imports alphabetical', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
 
     preg_match_all('/^use (.+);$/m', File::get($this->providers), $matches);
 
@@ -42,51 +42,51 @@ test('it keeps the provider imports alphabetical', function () {
 });
 
 test('it creates no layer directories', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
 
-    expect(app_path('Billing/Domain'))->not->toBeDirectory()
-        ->and(app_path('Billing/Application'))->not->toBeDirectory()
-        ->and(app_path('Billing/Infrastructure'))->not->toBeDirectory();
+    expect(app_path('ScaffoldFixture/Domain'))->not->toBeDirectory()
+        ->and(app_path('ScaffoldFixture/Application'))->not->toBeDirectory()
+        ->and(app_path('ScaffoldFixture/Infrastructure'))->not->toBeDirectory();
 });
 
 test('route files are opt in', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
 
-    expect(app_path('Billing/Shared/Infrastructure/Http/Routes/web.php'))->not->toBeFile();
+    expect(app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes/web.php'))->not->toBeFile();
 
     // The convention is documented as a comment, never as a live property
     // pointing at a file that does not exist.
-    expect(File::get(app_path('Billing/BillingServiceProvider.php')))
+    expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
         ->toContain('// protected array $routes')
         ->not->toMatch('/^\s+protected array \$routes/m');
 });
 
 test('it declares the route files it generates', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing', '--web' => true, '--api' => true])
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true, '--api' => true])
         ->assertSuccessful();
 
-    expect(app_path('Billing/Shared/Infrastructure/Http/Routes/web.php'))->toBeFile()
-        ->and(app_path('Billing/Shared/Infrastructure/Http/Routes/api.php'))->toBeFile();
+    expect(app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes/web.php'))->toBeFile()
+        ->and(app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes/api.php'))->toBeFile();
 
-    expect(File::get(app_path('Billing/BillingServiceProvider.php')))
+    expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
         ->toContain("'web' => [__DIR__.'/Shared/Infrastructure/Http/Routes/web.php']")
         ->toContain("'api' => [__DIR__.'/Shared/Infrastructure/Http/Routes/api.php']");
 });
 
 test('it refuses to overwrite an existing context', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing'])->assertSuccessful();
-    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing'])->assertFailed();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertFailed();
 });
 
 test('it normalises the context name', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'billing'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'scaffoldfixture'])->assertSuccessful();
 
-    expect(app_path('Billing/BillingServiceProvider.php'))->toBeFile();
+    expect(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php'))->toBeFile();
 });
 
 test('registering an already known provider does not duplicate it', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing'])->assertSuccessful();
-    $this->artisan('ldd:make:bounded-context', ['name' => 'Billing', '--force' => true])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--force' => true])->assertSuccessful();
 
-    expect(substr_count(File::get($this->providers), 'BillingServiceProvider::class'))->toBe(1);
+    expect(substr_count(File::get($this->providers), 'ScaffoldFixtureServiceProvider::class'))->toBe(1);
 });

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -120,6 +120,16 @@ test('it fails loudly when the provider list cannot be found', function () {
     expect(File::get($this->providers))->not->toContain('ScaffoldFixture');
 });
 
+test('a provider already listed fully qualified is not added again', function () {
+    // Laravel generates bootstrap/providers.php with no imports at all, so
+    // this is the shape a fresh application actually ships.
+    File::put($this->providers, "<?php\n\nreturn [\n    App\Shared\SharedServiceProvider::class,\n    App\ScaffoldFixture\ScaffoldFixtureServiceProvider::class,\n];\n");
+
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+
+    expect(substr_count(File::get($this->providers), 'ScaffoldFixtureServiceProvider::class'))->toBe(1);
+});
+
 test('a context is not mistaken for one whose name ends with it', function () {
     $this->artisan('ldd:make:bounded-context', ['name' => 'NestedScaffoldFixture'])->assertSuccessful();
 

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -14,9 +14,11 @@ beforeEach(function () {
     $this->providers = base_path('bootstrap/providers.php');
     $this->providersBackup = File::get($this->providers);
 
-    expect(app_path('ScaffoldFixture'))->not->toBeDirectory(
-        'app/ScaffoldFixture already exists; refusing to run so the teardown cannot delete it.'
-    );
+    foreach (['ScaffoldFixture', 'NestedScaffoldFixture'] as $fixture) {
+        expect(app_path($fixture))->not->toBeDirectory(
+            "app/{$fixture} already exists; refusing to run so the teardown cannot delete it."
+        );
+    }
 
     $this->createdFixture = true;
 });
@@ -24,8 +26,12 @@ beforeEach(function () {
 afterEach(function () {
     File::put($this->providers, $this->providersBackup);
 
+    // Removed here rather than in the test body: an assertion that fails
+    // leaves whatever the body had not reached yet, and a leaked context
+    // makes every later run of the suite fail too.
     if ($this->createdFixture ?? false) {
         File::deleteDirectory(app_path('ScaffoldFixture'));
+        File::deleteDirectory(app_path('NestedScaffoldFixture'));
     }
 });
 
@@ -92,6 +98,39 @@ test('it normalises the context name', function () {
     $this->artisan('ldd:make:bounded-context', ['name' => 'scaffold_fixture'])->assertSuccessful();
 
     expect(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php'))->toBeFile();
+});
+
+test('it registers the provider however the list is written', function () {
+    File::put($this->providers, "<?php\n\nreturn [App\Shared\SharedServiceProvider::class];\n");
+
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+
+    expect(File::get($this->providers))->toContain('ScaffoldFixtureServiceProvider::class,')
+        ->and(php_parses($this->providers))->toBeTrue();
+});
+
+test('it fails loudly when the provider list cannot be found', function () {
+    File::put($this->providers, "<?php\n\nreturn array(App\Shared\SharedServiceProvider::class);\n");
+
+    // Reporting success here leaves a context whose bindings, migrations and
+    // routes are never loaded, and a stale import would make every later run
+    // answer "already registered".
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertFailed();
+
+    expect(File::get($this->providers))->not->toContain('ScaffoldFixture');
+});
+
+test('a context is not mistaken for one whose name ends with it', function () {
+    $this->artisan('ldd:make:bounded-context', ['name' => 'NestedScaffoldFixture'])->assertSuccessful();
+
+    // NestedScaffoldFixtureServiceProvider::class contains
+    // ScaffoldFixtureServiceProvider::class, so a substring check would call
+    // this one already registered and never add it.
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+
+    expect(File::get($this->providers))
+        ->toContain("\n    ScaffoldFixtureServiceProvider::class,")
+        ->and(php_parses($this->providers))->toBeTrue();
 });
 
 test('registering an already known provider does not duplicate it', function () {

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -5,17 +5,27 @@ use Illuminate\Support\Facades\File;
 /*
  * The command writes into app/ and bootstrap/providers.php, so every test
  * restores both afterwards.
+ *
+ * The teardown only deletes directories that were absent when the test
+ * started: these tests run inside somebody else's application, and a context
+ * name that happened to collide would otherwise be destroyed.
  */
 beforeEach(function () {
     $this->providers = base_path('bootstrap/providers.php');
     $this->providersBackup = File::get($this->providers);
+
+    expect(app_path('ScaffoldFixture'))->not->toBeDirectory(
+        'app/ScaffoldFixture already exists; refusing to run so the teardown cannot delete it.'
+    );
+
+    $this->createdFixture = true;
 });
 
 afterEach(function () {
     File::put($this->providers, $this->providersBackup);
 
-    foreach (['ScaffoldFixture', 'Reporting'] as $context) {
-        File::deleteDirectory(app_path($context));
+    if ($this->createdFixture ?? false) {
+        File::deleteDirectory(app_path('ScaffoldFixture'));
     }
 });
 

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -79,7 +79,7 @@ test('it refuses to overwrite an existing context', function () {
 });
 
 test('it normalises the context name', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'scaffoldfixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'scaffold_fixture'])->assertSuccessful();
 
     expect(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php'))->toBeFile();
 });

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -89,9 +89,33 @@ test('it declares the route files it generates', function () {
         ->toContain("'api' => [__DIR__.'/Shared/Infrastructure/Http/Routes/api.php']");
 });
 
-test('it refuses to overwrite an existing context', function () {
+test('re-running never rewrites the provider', function () {
     $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertFailed();
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true])
+        ->assertSuccessful();
+
+    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+    $before = File::get($provider);
+
+    // Asking for route files on a context already in use is the natural way
+    // to run this twice; rewriting the provider from the stub would drop
+    // every binding and migration path it has accumulated.
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true])
+        ->assertSuccessful();
+
+    expect(File::get($provider))->toBe($before);
+});
+
+test('re-running creates the missing route file and says how to declare it', function () {
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+
+    // The file alone is never loaded: the provider has to declare it, and
+    // the provider is the one thing this command will not touch.
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true])
+        ->expectsOutputToContain("'web' => [__DIR__.'/Shared/Infrastructure/Http/Routes/web.php'],")
+        ->assertSuccessful();
+
+    expect(app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes/web.php'))->toBeFile();
 });
 
 test('it normalises the context name', function () {
@@ -143,36 +167,9 @@ test('a context is not mistaken for one whose name ends with it', function () {
         ->and(php_parses($this->providers))->toBeTrue();
 });
 
-test('force refuses to regenerate a provider that declares anything', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
-    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true])
-        ->assertSuccessful();
-
-    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
-    $before = File::get($provider);
-
-    // Asking for route files on a context already in use is the natural way
-    // to reach --force, and regenerating from the stub would drop every
-    // binding and migration path while reporting success.
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true, '--force' => true])
-        ->assertFailed();
-
-    expect(File::get($provider))->toBe($before);
-});
-
-test('force regenerates a provider that declares nothing', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
-
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true, '--force' => true])
-        ->assertSuccessful();
-
-    expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
-        ->toContain("'web' => [__DIR__.'/Shared/Infrastructure/Http/Routes/web.php']");
-});
-
 test('registering an already known provider does not duplicate it', function () {
     $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--force' => true])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
 
     expect(substr_count(File::get($this->providers), 'ScaffoldFixtureServiceProvider::class'))->toBe(1);
 });

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -143,6 +143,33 @@ test('a context is not mistaken for one whose name ends with it', function () {
         ->and(php_parses($this->providers))->toBeTrue();
 });
 
+test('force refuses to regenerate a provider that declares anything', function () {
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true])
+        ->assertSuccessful();
+
+    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+    $before = File::get($provider);
+
+    // Asking for route files on a context already in use is the natural way
+    // to reach --force, and regenerating from the stub would drop every
+    // binding and migration path while reporting success.
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true, '--force' => true])
+        ->assertFailed();
+
+    expect(File::get($provider))->toBe($before);
+});
+
+test('force regenerates a provider that declares nothing', function () {
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true, '--force' => true])
+        ->assertSuccessful();
+
+    expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
+        ->toContain("'web' => [__DIR__.'/Shared/Infrastructure/Http/Routes/web.php']");
+});
+
 test('registering an already known provider does not duplicate it', function () {
     $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
     $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--force' => true])->assertSuccessful();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -48,3 +48,17 @@ function something()
 {
     // ..
 }
+
+/**
+ * Whether a generated PHP file actually parses.
+ *
+ * The scaffolding commands rewrite service providers, and a malformed one is
+ * registered in bootstrap/providers.php: asserting on the file's contents
+ * would not notice that the application can no longer boot.
+ */
+function php_parses(string $path): bool
+{
+    exec('php -l '.escapeshellarg($path).' 2>&1', $output, $status);
+
+    return $status === 0;
+}


### PR DESCRIPTION
Closes #24
Closes #64

Generates an aggregate inside an existing context and, crucially, wires it: the repository binding goes into the provider's `$bindings` and, with `--migration`, the path goes into `$migrations`. Those two are the silent failures the issue was about — an unbound contract and a table that never gets created.

Core is the aggregate root, its repository contract and Eloquent implementation, and its exceptions. Everything else is opt in — `--migration`, `--factory`, `--events`, `--requests`, `--web`, `--api`, `--all` — because only `Infrastructure` appears in all 15 aggregates of the production app this starter came from, and `Domain/Events` in 5.

`--web` covers #64: an Inertia controller extending `InertiaController` and rendering through `$this->render()` rather than `Inertia::render`. Neither the route nor the Vue page is written — routes live in a file the developer owns and the page sits outside `app/` under a path `vite.config.js` decides — so both are printed for pasting.

Two details worth reviewing: `--factory` also writes `newFactory()` on the model, since Laravel would not find a factory living in Infrastructure — that is the Domain to Infrastructure coupling the architecture test exempts, and the derived ignore list from #50 picked the generated model up on its own. The shared plumbing moved to a `ScaffoldCommand` base, so `ldd:make:bounded-context` lost its duplicated copy.

Verified by generating a full aggregate and running it: migration applied through the declarative path, container resolved the binding, uuid assigned before save, factory routed through `new()`, repository round-tripped. Pint, PHPStan and the architecture tests all pass on the generated code.