### PR TITLE
feat: #66 add ldd:make:use-case and ldd:make:event-handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,24 @@ resolvable at all. Everything else is opt in, because real aggregates rarely nee
 The table name defaults to the pluralised aggregate. Two contexts may each own an `Invoice`, but
 only one can create the `invoices` table, so `--table=billing_invoices` renames it for the second.
 
-An aggregate records its domain events; publishing them belongs to a use case, which injects
-`EventBus` and calls `publishDomainEvents()` inside the transaction that saved the aggregate. Until
-one exists the events go nowhere, so `--events` prints the two lines that close the loop.
+An aggregate records its domain events; publishing them belongs to the application layer, which is
+what the last two commands fill in:
 
-Both commands only ever add. Run one again with a flag you skipped and it writes what is missing,
+```bash
+./vendor/bin/sail artisan ldd:make:use-case Billing Invoice CreateInvoice --publishes
+./vendor/bin/sail artisan ldd:make:event-handler Billing Invoice NotifyAccounting --queued
+```
+
+`--publishes` writes the idiom that closes the loop: save through the repository and publish the
+recorded events inside the same transaction, so a failing listener cannot leave the aggregate
+persisted. Without it the events pile up on the instance and vanish with it.
+
+The handler is the one that needs wiring. It is declared in the provider's `$events`, and one that
+is missing from there is simply never called — which is why the command refuses to add a second
+handler for an event that already has one, rather than leave two entries under a key where PHP
+keeps only the last.
+
+All four commands only ever add. Run one again with a flag you skipped and it writes what is missing,
 leaves every file already on disk alone — your migration may have been applied, and the provider
 carries wiring no stub knows about — and prints the lines to add by hand.
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
@@ -62,7 +62,12 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
         // $events is keyed by the event class, and a duplicate key in an array
         // literal silently drops the earlier one. Checked before anything is
         // written, so a refusal leaves no orphan handler behind.
-        if (preg_match('/(?<![\w\\\\])'.preg_quote($event, '/').'::class\s*=>/', $contents) === 1) {
+        //
+        // Comments are stripped first: a mapping somebody parked behind // is
+        // not a mapping, and would otherwise block the command outright.
+        $declared = (string) preg_replace('#/\*.*?\*/|//[^\n]*#s', '', $contents);
+
+        if (preg_match('/(?<![\w\\\\])'.preg_quote($event, '/').'::class\s*=>/', $declared) === 1) {
             $this->components->error("[{$event}] is already handled in {$target['context']}ServiceProvider.");
             $this->components->bulletList([
                 'Declare the second handler by hand: PHP would drop one of two entries under the same key.',
@@ -71,7 +76,12 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
-        $this->put("{$target['path']}/Application/EventHandlers/{$name}.php", $this->stub('event-handler', [
+        $handler = "{$target['path']}/Application/EventHandlers/{$name}.php";
+
+        // put() reports whether it wrote. Adding the import to a handler this
+        // run did not create leaves it on a class that never gains the
+        // implements clause, which is an unused import and a lie.
+        $written = $this->put($handler, $this->stub('event-handler', [
             '{{ context }}' => $target['context'],
             '{{ plural }}' => $target['plural'],
             '{{ name }}' => $name,
@@ -80,7 +90,7 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
         ]));
 
         if ($this->option('queued')) {
-            $this->queueTheHandler("{$target['path']}/Application/EventHandlers/{$name}.php");
+            $written ? $this->queueTheHandler($handler) : $this->printQueuedHint($handler, $name);
         }
 
         $wired = $this->wireProvider($provider, $contents, $target, $name, $event);
@@ -91,6 +101,19 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
         // The handler exists but nothing calls it, so a script chaining on
         // this command must not treat it as done.
         return $wired ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * What the handler already declares decides this: asking for --queued on
+     * one that is already queued has nothing to say.
+     */
+    private function printQueuedHint(string $file, string $name): void
+    {
+        if (str_contains($this->files->get($file), 'ShouldQueue')) {
+            return;
+        }
+
+        $this->components->warn("{$name} already existed and was left as it is. Add `implements ShouldQueue` to it by hand.");
     }
 
     private function queueTheHandler(string $file): void

--- a/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
@@ -96,7 +96,7 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
         $wired = $this->wireProvider($provider, $contents, $target, $name, $event);
 
         $this->newLine();
-        $this->components->info("Event handler [{$name}] created in [{$target['context']}].");
+        $this->components->info("Event handler [{$name}] ".($written ? 'created' : 'declared')." in [{$target['context']}].");
 
         // The handler exists but nothing calls it, so a script chaining on
         // this command must not treat it as done.

--- a/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Console\Commands;
+
+/**
+ * Class MakeEventHandlerCommand
+ *
+ * Adds a domain event handler and declares it in the context's provider.
+ *
+ * The declaration is the point. A handler that is not listed in $events is
+ * never called, and nothing anywhere says so: it is the same silent failure
+ * as an unbound repository or an unregistered migration path.
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+final class MakeEventHandlerCommand extends ScaffoldCommand
+{
+    protected $signature = 'ldd:make:event-handler
+        {context : The bounded context it belongs to, e.g. Billing}
+        {aggregate : The aggregate whose event it handles, e.g. Invoice}
+        {name : The handler name, e.g. NotifyAccounting}
+        {--event= : The domain event, defaults to <Aggregate>Created}
+        {--queued : Handle the event on the queue}';
+
+    protected $description = 'Create a domain event handler and declare it in the provider';
+
+    public function handle(): int
+    {
+        $target = $this->target(
+            (string) $this->argument('context'),
+            (string) $this->argument('aggregate'),
+        );
+        $name = $this->identifier((string) $this->argument('name'), 'handler');
+
+        if ($target === null || $name === null) {
+            return self::FAILURE;
+        }
+
+        $event = $this->identifier(
+            (string) ($this->option('event') ?: "{$target['aggregate']}Created"),
+            'event'
+        );
+
+        if ($event === null) {
+            return self::FAILURE;
+        }
+
+        if (! $this->files->exists("{$target['path']}/Domain/Events/{$event}.php")) {
+            $this->components->error("[{$event}] does not exist in [{$target['aggregate']}].");
+            $this->components->bulletList([
+                "Add it with: php artisan ldd:make:aggregate {$target['context']} {$target['aggregate']} --events",
+            ]);
+
+            return self::FAILURE;
+        }
+
+        $provider = app_path("{$target['context']}/{$target['context']}ServiceProvider.php");
+        $contents = $this->files->get($provider);
+
+        // $events is keyed by the event class, and a duplicate key in an array
+        // literal silently drops the earlier one. Checked before anything is
+        // written, so a refusal leaves no orphan handler behind.
+        if (preg_match('/(?<![\w\\\\])'.preg_quote($event, '/').'::class\s*=>/', $contents) === 1) {
+            $this->components->error("[{$event}] is already handled in {$target['context']}ServiceProvider.");
+            $this->components->bulletList([
+                'Declare the second handler by hand: PHP would drop one of two entries under the same key.',
+            ]);
+
+            return self::FAILURE;
+        }
+
+        $this->put("{$target['path']}/Application/EventHandlers/{$name}.php", $this->stub('event-handler', [
+            '{{ context }}' => $target['context'],
+            '{{ plural }}' => $target['plural'],
+            '{{ name }}' => $name,
+            '{{ event }}' => $event,
+            '{{ handlerImplements }}' => $this->option('queued') ? ' implements ShouldQueue' : '',
+        ]));
+
+        if ($this->option('queued')) {
+            $this->queueTheHandler("{$target['path']}/Application/EventHandlers/{$name}.php");
+        }
+
+        $wired = $this->wireProvider($provider, $contents, $target, $name, $event);
+
+        $this->newLine();
+        $this->components->info("Event handler [{$name}] created in [{$target['context']}].");
+
+        // The handler exists but nothing calls it, so a script chaining on
+        // this command must not treat it as done.
+        return $wired ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function queueTheHandler(string $file): void
+    {
+        $imported = $this->withImport($this->files->get($file), 'Illuminate\Contracts\Queue\ShouldQueue');
+
+        if ($imported === null) {
+            $this->components->warn('Import Illuminate\Contracts\Queue\ShouldQueue in the handler by hand.');
+
+            return;
+        }
+
+        $this->files->put($file, $imported);
+    }
+
+    /**
+     * @param  array{context: string, aggregate: string, plural: string, path: string}  $target
+     */
+    private function wireProvider(string $provider, string $contents, array $target, string $name, string $event): bool
+    {
+        $handlerClass = "App\\{$target['context']}\\{$target['plural']}\\Application\\EventHandlers\\{$name}";
+        $eventClass = "App\\{$target['context']}\\{$target['plural']}\\Domain\\Events\\{$event}";
+
+        $updated = $this->withImport($contents, $eventClass);
+        $updated = $updated === null ? null : $this->withImport($updated, $handlerClass);
+        $updated = $updated === null
+            ? null
+            : $this->appendToList($updated, 'array $events = [', "        {$event}::class => {$name}::class,");
+
+        if ($updated === null) {
+            $this->components->twoColumnDetail($this->relative($provider), '<fg=red>could not be wired</>');
+            $this->components->warn("Map {$event}::class to {$name}::class in {$target['context']}ServiceProvider::\$events by hand.");
+
+            return false;
+        }
+
+        $this->files->put($provider, $updated);
+        $this->components->twoColumnDetail($this->relative($provider), '<fg=green>wired</>');
+
+        return true;
+    }
+}

--- a/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
@@ -42,7 +42,10 @@ final class MakeUseCaseCommand extends ScaffoldCommand
 
         $stub = $this->option('publishes') ? 'use-case.publishes' : 'use-case';
 
-        $this->put("{$target['path']}/Application/{$name}.php", $this->stub($stub, [
+        // put() reports whether it wrote, and saying "created" over the top of
+        // its own "exists, skipped" is how a run that did nothing reads like
+        // one that did.
+        $written = $this->put("{$target['path']}/Application/{$name}.php", $this->stub($stub, [
             '{{ context }}' => $target['context'],
             '{{ aggregate }}' => $target['aggregate'],
             '{{ plural }}' => $target['plural'],
@@ -51,7 +54,7 @@ final class MakeUseCaseCommand extends ScaffoldCommand
         ]));
 
         $this->newLine();
-        $this->components->info("Use case [{$name}] created in [{$target['context']}].");
+        $this->components->info("Use case [{$name}] ".($written ? 'created' : 'left as it is')." in [{$target['context']}].");
 
         $this->printPublishHint($target);
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
@@ -73,6 +73,19 @@ final class MakeUseCaseCommand extends ScaffoldCommand
             return;
         }
 
+        // And only until something publishes them. This is the same question
+        // ldd:make:aggregate asks before printing its own version, and the two
+        // have no business disagreeing about the answer.
+        $application = "{$target['path']}/Application";
+
+        if ($this->files->isDirectory($application)) {
+            foreach ($this->files->allFiles($application) as $file) {
+                if (str_contains($file->getContents(), 'publishDomainEvents')) {
+                    return;
+                }
+            }
+        }
+
         $this->newLine();
         $this->line("  <fg=yellow>{$target['aggregate']} records domain events. A use case that creates or changes one</>");
         $this->line('  <fg=yellow>should publish them, which is what --publishes scaffolds.</>');

--- a/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Console\Commands;
+
+use Illuminate\Support\Str;
+
+/**
+ * Class MakeUseCaseCommand
+ *
+ * Adds a use case to an aggregate's Application layer.
+ *
+ * Nothing needs wiring: the container resolves the constructor by itself.
+ * What this saves is the shape — a final readonly class that reaches the
+ * domain only through the repository contract — and, with --publishes, the
+ * one idiom that is easy to leave out and impossible to notice missing.
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+final class MakeUseCaseCommand extends ScaffoldCommand
+{
+    protected $signature = 'ldd:make:use-case
+        {context : The bounded context it belongs to, e.g. Billing}
+        {aggregate : The aggregate it operates on, e.g. Invoice}
+        {name : The use case name, e.g. CreateInvoice}
+        {--publishes : Save through a transaction and publish the recorded domain events}';
+
+    protected $description = 'Create a use case in an aggregate\'s application layer';
+
+    public function handle(): int
+    {
+        $target = $this->target(
+            (string) $this->argument('context'),
+            (string) $this->argument('aggregate'),
+        );
+        $name = $this->identifier((string) $this->argument('name'), 'use case');
+
+        if ($target === null || $name === null) {
+            return self::FAILURE;
+        }
+
+        $stub = $this->option('publishes') ? 'use-case.publishes' : 'use-case';
+
+        $this->put("{$target['path']}/Application/{$name}.php", $this->stub($stub, [
+            '{{ context }}' => $target['context'],
+            '{{ aggregate }}' => $target['aggregate'],
+            '{{ plural }}' => $target['plural'],
+            '{{ variable }}' => Str::camel($target['aggregate']),
+            '{{ name }}' => $name,
+        ]));
+
+        $this->newLine();
+        $this->components->info("Use case [{$name}] created in [{$target['context']}].");
+
+        $this->printPublishHint($target);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array{context: string, aggregate: string, plural: string, path: string}  $target
+     */
+    private function printPublishHint(array $target): void
+    {
+        if ($this->option('publishes')) {
+            return;
+        }
+
+        // Only worth saying when the aggregate has events to lose: what the
+        // domain already holds decides this, not the flag.
+        if (! $this->files->isDirectory("{$target['path']}/Domain/Events")) {
+            return;
+        }
+
+        $this->newLine();
+        $this->line("  <fg=yellow>{$target['aggregate']} records domain events. A use case that creates or changes one</>");
+        $this->line('  <fg=yellow>should publish them, which is what --publishes scaffolds.</>');
+    }
+}

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -77,6 +77,54 @@ abstract class ScaffoldCommand extends Command
     }
 
     /**
+     * Resolves an existing aggregate from the names it was given.
+     *
+     * The names are passed in rather than read here: a base class cannot
+     * know which arguments its subclasses declare, and reaching for one that
+     * does not exist is a runtime error waiting for whoever adds the next
+     * command.
+     *
+     * Returns null, having said why, when either is missing: these commands
+     * add to an aggregate that exists, they never create one.
+     *
+     * @return array{context: string, aggregate: string, plural: string, path: string}|null
+     */
+    protected function target(string $contextName, string $aggregateName): ?array
+    {
+        $context = $this->identifier($contextName, 'bounded context');
+        $aggregate = $this->identifier($aggregateName, 'aggregate');
+
+        if ($context === null || $aggregate === null) {
+            return null;
+        }
+
+        // A directory alone is not a context: it also has to be wired by a
+        // provider named after it, which is what these commands edit.
+        if (! $this->files->exists(app_path("{$context}/{$context}ServiceProvider.php"))) {
+            $this->components->error("The bounded context [{$context}] does not exist.");
+            $this->components->bulletList([
+                "Create it with: php artisan ldd:make:bounded-context {$context}",
+            ]);
+
+            return null;
+        }
+
+        $plural = Str::plural($aggregate);
+        $path = app_path("{$context}/{$plural}");
+
+        if (! $this->files->isDirectory($path)) {
+            $this->components->error("The aggregate [{$aggregate}] does not exist in [{$context}].");
+            $this->components->bulletList([
+                "Create it with: php artisan ldd:make:aggregate {$context} {$aggregate}",
+            ]);
+
+            return null;
+        }
+
+        return compact('context', 'aggregate', 'plural', 'path');
+    }
+
+    /**
      * @param  array<string, string>  $replacements
      */
     protected function stub(string $name, array $replacements): string

--- a/app/Shared/SharedServiceProvider.php
+++ b/app/Shared/SharedServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Shared;
 
 use App\Shared\Infrastructure\Console\Commands\MakeAggregateCommand;
 use App\Shared\Infrastructure\Console\Commands\MakeBoundedContextCommand;
+use App\Shared\Infrastructure\Console\Commands\MakeEventHandlerCommand;
+use App\Shared\Infrastructure\Console\Commands\MakeUseCaseCommand;
 use ComplexHeart\Domain\Contracts\Events\EventBus;
 use ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;
 use ComplexHeart\Infrastructure\Laravel\ServiceBus\IlluminateEventBus;
@@ -36,6 +38,8 @@ class SharedServiceProvider extends BoundedContextServiceProvider
     protected array $commands = [
         MakeAggregateCommand::class,
         MakeBoundedContextCommand::class,
+        MakeEventHandlerCommand::class,
+        MakeUseCaseCommand::class,
     ];
 
     public function boot(): void

--- a/stubs/event-handler.stub
+++ b/stubs/event-handler.stub
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Application\EventHandlers;
+
+use App\{{ context }}\{{ plural }}\Domain\Events\{{ event }};
+
+/**
+ * Class {{ name }}
+ *
+ * Registered in {{ context }}ServiceProvider::$events. A handler that is not
+ * declared there is simply never called, with nothing to say so.
+ */
+final readonly class {{ name }}{{ handlerImplements }}
+{
+    public function handle({{ event }} $event): void
+    {
+        //
+    }
+}

--- a/stubs/use-case.publishes.stub
+++ b/stubs/use-case.publishes.stub
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Application;
+
+use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
+use App\{{ context }}\{{ plural }}\Domain\{{ aggregate }};
+use ComplexHeart\Domain\Contracts\Events\EventBus;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Class {{ name }}
+ *
+ * An aggregate only records its domain events. Publishing them is this
+ * layer's job, and nothing else does it: without a use case like this one
+ * the events pile up on the instance and vanish with it.
+ */
+final readonly class {{ name }}
+{
+    public function __construct(
+        private {{ aggregate }}Repository $repository,
+        private EventBus $eventBus,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    public function __invoke(array $input): {{ aggregate }}
+    {
+        // Publishing inside the transaction keeps a failing listener from
+        // leaving a persisted aggregate behind a request that never finished.
+        return DB::transaction(function () use ($input): {{ aggregate }} {
+            ${{ variable }} = $this->repository->save({{ aggregate }}::new($input));
+
+            ${{ variable }}->publishDomainEvents($this->eventBus);
+
+            return ${{ variable }};
+        });
+    }
+}

--- a/stubs/use-case.stub
+++ b/stubs/use-case.stub
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Application;
+
+use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
+use App\{{ context }}\{{ plural }}\Domain\{{ aggregate }};
+
+/**
+ * Class {{ name }}
+ *
+ * One use case, one public entry point. It talks to the domain through the
+ * repository contract, never to Eloquent, which is what keeps this layer
+ * testable and the architecture rules satisfied.
+ */
+final readonly class {{ name }}
+{
+    public function __construct(private {{ aggregate }}Repository $repository) {}
+
+    public function __invoke({{ aggregate }} ${{ variable }}): {{ aggregate }}
+    {
+        return $this->repository->save(${{ variable }});
+    }
+}

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+/*
+ * Every test starts from a freshly generated context and aggregate, and the
+ * teardown only deletes a directory this file created: in a starter kit these
+ * tests run inside somebody else's application, and a fixture name that
+ * happened to collide would otherwise take their context with it.
+ */
+beforeEach(function () {
+    $this->providers = base_path('bootstrap/providers.php');
+    $this->providersBackup = File::get($this->providers);
+
+    expect(app_path('ScaffoldFixture'))->not->toBeDirectory(
+        'app/ScaffoldFixture already exists; refusing to run so the teardown cannot delete it.'
+    );
+
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
+        ->assertSuccessful();
+
+    $this->provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+    $this->createdFixture = true;
+});
+
+afterEach(function () {
+    File::put($this->providers, $this->providersBackup);
+
+    if ($this->createdFixture ?? false) {
+        File::deleteDirectory(app_path('ScaffoldFixture'));
+    }
+});
+
+test('it creates the handler and declares it in the provider', function () {
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
+    ])->assertSuccessful();
+
+    expect(app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php'))->toBeFile();
+
+    // The declaration is the point: a handler missing from $events is never
+    // called and nothing anywhere says so.
+    expect(File::get($this->provider))
+        ->toContain('use App\ScaffoldFixture\Widgets\Application\EventHandlers\NotifyAccounting;')
+        ->toContain('use App\ScaffoldFixture\Widgets\Domain\Events\WidgetCreated;')
+        ->toContain('WidgetCreated::class => NotifyAccounting::class,')
+        ->and(php_parses($this->provider))->toBeTrue();
+});
+
+test('queued makes the handler implement ShouldQueue', function () {
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting', '--queued' => true,
+    ])->assertSuccessful();
+
+    $file = app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
+
+    expect(File::get($file))
+        ->toContain('use Illuminate\Contracts\Queue\ShouldQueue;')
+        ->toContain('final readonly class NotifyAccounting implements ShouldQueue')
+        ->and(php_parses($file))->toBeTrue();
+});
+
+test('it defaults to the Created event and accepts another', function () {
+    $this->artisan('ldd:make:aggregate', [
+        'context' => 'ScaffoldFixture', 'name' => 'Gadget', '--events' => true,
+    ])->assertSuccessful();
+
+    File::copy(
+        app_path('ScaffoldFixture/Gadgets/Domain/Events/GadgetCreated.php'),
+        $paid = app_path('ScaffoldFixture/Gadgets/Domain/Events/GadgetPaid.php')
+    );
+    File::put($paid, str_replace('GadgetCreated', 'GadgetPaid', File::get($paid)));
+
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Gadget', 'name' => 'OnPaid', '--event' => 'GadgetPaid',
+    ])->assertSuccessful();
+
+    expect(File::get($this->provider))->toContain('GadgetPaid::class => OnPaid::class,');
+});
+
+test('it refuses an event the aggregate does not have', function () {
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'OnPaid', '--event' => 'WidgetPaid',
+    ])->assertFailed();
+
+    expect(app_path('ScaffoldFixture/Widgets/Application/EventHandlers'))->not->toBeDirectory();
+});
+
+test('it refuses a second handler for the same event', function () {
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
+    ])->assertSuccessful();
+
+    // Two entries under one key: PHP keeps the last and drops the first, with
+    // no error, so the first handler would quietly stop running.
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'AlsoNotify',
+    ])->assertFailed();
+
+    expect(app_path('ScaffoldFixture/Widgets/Application/EventHandlers/AlsoNotify.php'))->not->toBeFile()
+        ->and(substr_count(File::get($this->provider), 'WidgetCreated::class =>'))->toBe(1);
+});
+
+test('it fails when the provider has no events array to declare in', function () {
+    File::put($this->provider, "<?php\n\nnamespace App\ScaffoldFixture;\n\nuse ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;\n\nclass ScaffoldFixtureServiceProvider extends BoundedContextServiceProvider\n{\n}\n");
+
+    // The handler exists but nothing calls it, so this must not report success.
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
+    ])->assertFailed();
+
+    expect(File::get($this->provider))->not->toContain('NotifyAccounting');
+});

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -140,6 +140,25 @@ test('queued leaves a handler it did not write alone', function () {
         ->not->toContain('ShouldQueue');
 });
 
+test('it does not claim to have created a handler it skipped', function () {
+    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting'];
+
+    $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();
+
+    File::put($this->provider, str_replace(
+        '        WidgetCreated::class => NotifyAccounting::class,'."\n",
+        '',
+        File::get($this->provider)
+    ));
+
+    // The run still does something worth reporting — it declares the mapping —
+    // but it did not create the handler and must not say it did.
+    $this->artisan('ldd:make:event-handler', $args)
+        ->expectsOutputToContain('exists, skipped')
+        ->expectsOutputToContain('[NotifyAccounting] declared in [ScaffoldFixture]')
+        ->assertSuccessful();
+});
+
 test('it fails when the provider has no events array to declare in', function () {
     File::put($this->provider, "<?php\n\nnamespace App\ScaffoldFixture;\n\nuse ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;\n\nclass ScaffoldFixtureServiceProvider extends BoundedContextServiceProvider\n{\n}\n");
 

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -102,6 +102,44 @@ test('it refuses a second handler for the same event', function () {
         ->and(substr_count(File::get($this->provider), 'WidgetCreated::class =>'))->toBe(1);
 });
 
+test('a commented out mapping does not block the command', function () {
+    File::put($this->provider, str_replace(
+        'protected array $events = [];',
+        "protected array \$events = [\n        // WidgetCreated::class => SomeOldHandler::class,\n    ];",
+        File::get($this->provider)
+    ));
+
+    // Something parked behind // is not a mapping, and refusing on it leaves
+    // the developer with no way to add the handler at all.
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
+    ])->assertSuccessful();
+
+    expect(File::get($this->provider))->toContain('WidgetCreated::class => NotifyAccounting::class,');
+});
+
+test('queued leaves a handler it did not write alone', function () {
+    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting'];
+
+    $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();
+
+    // Reached by the command's own recovery path: the handler exists from a
+    // run that could not wire it. Importing ShouldQueue into a class that
+    // never gains the implements clause is an unused import Pint rejects.
+    File::put($this->provider, str_replace(
+        '        WidgetCreated::class => NotifyAccounting::class,'."\n",
+        '',
+        File::get($this->provider)
+    ));
+
+    $this->artisan('ldd:make:event-handler', $args + ['--queued' => true])
+        ->expectsOutputToContain('already existed and was left as it is')
+        ->assertSuccessful();
+
+    expect(File::get(app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php')))
+        ->not->toContain('ShouldQueue');
+});
+
 test('it fails when the provider has no events array to declare in', function () {
     File::put($this->provider, "<?php\n\nnamespace App\ScaffoldFixture;\n\nuse ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;\n\nclass ScaffoldFixtureServiceProvider extends BoundedContextServiceProvider\n{\n}\n");
 

--- a/tests/Feature/Shared/MakeUseCaseCommandTest.php
+++ b/tests/Feature/Shared/MakeUseCaseCommandTest.php
@@ -72,6 +72,20 @@ test('it points at publishes when the aggregate records events', function () {
         ->assertSuccessful();
 });
 
+test('it stops advising publishes once something publishes', function () {
+    $this->artisan('ldd:make:use-case', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'CreateWidget', '--publishes' => true,
+    ])->assertSuccessful();
+
+    // The loop is closed, and a read use case should not publish anyway.
+    // ldd:make:aggregate asks the same question; the two must agree.
+    $this->artisan('ldd:make:use-case', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
+    ])
+        ->doesntExpectOutputToContain('records domain events')
+        ->assertSuccessful();
+});
+
 test('it stays quiet when the aggregate has no events to lose', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Gadget'])
         ->assertSuccessful();

--- a/tests/Feature/Shared/MakeUseCaseCommandTest.php
+++ b/tests/Feature/Shared/MakeUseCaseCommandTest.php
@@ -111,6 +111,19 @@ test('it refuses a context that does not exist', function () {
     ])->assertFailed();
 });
 
+test('it does not claim to have created a file it skipped', function () {
+    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget'];
+
+    $this->artisan('ldd:make:use-case', $args)->assertSuccessful();
+
+    // Saying "created" over the top of its own "exists, skipped" is how a run
+    // that did nothing reads like one that did.
+    $this->artisan('ldd:make:use-case', $args)
+        ->expectsOutputToContain('exists, skipped')
+        ->expectsOutputToContain('[FindWidget] left as it is')
+        ->assertSuccessful();
+});
+
 test('it never overwrites a use case that exists', function () {
     $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget'];
 

--- a/tests/Feature/Shared/MakeUseCaseCommandTest.php
+++ b/tests/Feature/Shared/MakeUseCaseCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+/*
+ * Every test starts from a freshly generated context and aggregate, and the
+ * teardown only deletes a directory this file created: in a starter kit these
+ * tests run inside somebody else's application, and a fixture name that
+ * happened to collide would otherwise take their context with it.
+ */
+beforeEach(function () {
+    $this->providers = base_path('bootstrap/providers.php');
+    $this->providersBackup = File::get($this->providers);
+
+    expect(app_path('ScaffoldFixture'))->not->toBeDirectory(
+        'app/ScaffoldFixture already exists; refusing to run so the teardown cannot delete it.'
+    );
+
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
+        ->assertSuccessful();
+
+    $this->createdFixture = true;
+});
+
+afterEach(function () {
+    File::put($this->providers, $this->providersBackup);
+
+    if ($this->createdFixture ?? false) {
+        File::deleteDirectory(app_path('ScaffoldFixture'));
+    }
+});
+
+test('it creates the use case in the aggregate application layer', function () {
+    $this->artisan('ldd:make:use-case', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
+    ])->assertSuccessful();
+
+    $file = app_path('ScaffoldFixture/Widgets/Application/FindWidget.php');
+
+    expect($file)->toBeFile()
+        ->and(File::get($file))
+        ->toContain('namespace App\ScaffoldFixture\Widgets\Application;')
+        ->toContain('final readonly class FindWidget')
+        // The application layer reaches the domain through the contract, which
+        // is what the architecture rules check and what keeps it testable.
+        ->toContain('private WidgetRepository $repository')
+        ->and(php_parses($file))->toBeTrue();
+});
+
+test('publishes scaffolds the transaction and the publish call', function () {
+    $this->artisan('ldd:make:use-case', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'CreateWidget', '--publishes' => true,
+    ])->assertSuccessful();
+
+    $file = app_path('ScaffoldFixture/Widgets/Application/CreateWidget.php');
+
+    // An aggregate only records its events. Without this the recorded events
+    // pile up on the instance and vanish with it.
+    expect(File::get($file))
+        ->toContain('private EventBus $eventBus')
+        ->toContain('DB::transaction(')
+        ->toContain('$widget->publishDomainEvents($this->eventBus);')
+        ->and(php_parses($file))->toBeTrue();
+});
+
+test('it points at publishes when the aggregate records events', function () {
+    $this->artisan('ldd:make:use-case', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
+    ])
+        ->expectsOutputToContain('Widget records domain events.')
+        ->assertSuccessful();
+});
+
+test('it stays quiet when the aggregate has no events to lose', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Gadget'])
+        ->assertSuccessful();
+
+    $this->artisan('ldd:make:use-case', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Gadget', 'name' => 'FindGadget',
+    ])
+        ->doesntExpectOutputToContain('records domain events')
+        ->assertSuccessful();
+});
+
+test('it refuses an aggregate that does not exist', function () {
+    $this->artisan('ldd:make:use-case', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Nope', 'name' => 'DoThing',
+    ])->assertFailed();
+
+    expect(app_path('ScaffoldFixture/Nopes'))->not->toBeDirectory();
+});
+
+test('it refuses a context that does not exist', function () {
+    $this->artisan('ldd:make:use-case', [
+        'context' => 'Nope', 'aggregate' => 'Widget', 'name' => 'DoThing',
+    ])->assertFailed();
+});
+
+test('it never overwrites a use case that exists', function () {
+    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget'];
+
+    $this->artisan('ldd:make:use-case', $args)->assertSuccessful();
+
+    $file = app_path('ScaffoldFixture/Widgets/Application/FindWidget.php');
+    File::put($file, File::get($file)."\n// hand written\n");
+
+    $this->artisan('ldd:make:use-case', $args)->assertSuccessful();
+
+    expect(File::get($file))->toContain('// hand written');
+});


### PR DESCRIPTION
Aggregates recorded domain events that nothing published, because nothing generated the application layer. These two commands fill it in.

`ldd:make:use-case --publishes` writes the save-and-publish-in-one-transaction idiom; `ldd:make:event-handler` declares the handler in the provider's `$events`, which is the wiring that fails silently when it is missing.

Partially closes #66: the remaining directories it lists (`Application/{Mail,Jobs,Notifications}`, `Persistence/Seeders`, `Infrastructure/Console/Commands`) already have Laravel generators and only need placing.