### PR TITLE
feat: #69 read PHP source with an AST instead of searching the text

### DIFF
--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Console\Commands;
 
+use App\Shared\Infrastructure\Console\Support\SourceFile;
 use Illuminate\Support\Str;
 
 /**
@@ -153,14 +154,14 @@ final class MakeAggregateCommand extends ScaffoldCommand
         // What the model already carries decides this, not the flags: running
         // the same command twice would otherwise advise redeclaring
         // newFactory(), which is fatal, and registering the event twice.
-        $model = $this->files->get("{$path}/Domain/{$this->aggregate}.php");
+        $model = SourceFile::at("{$path}/Domain/{$this->aggregate}.php");
         $lines = [];
 
-        if ($this->wants('events') && ! str_contains($model, 'registerDomainEvent')) {
+        if ($this->wants('events') && ! $model->calls('registerDomainEvent')) {
             $lines[] = "in new(): \${$this->variable}->registerDomainEvent({$this->aggregate}Created::new(\${$this->variable}->id));";
         }
 
-        if ($this->wants('factory') && ! str_contains($model, 'newFactory')) {
+        if ($this->wants('factory') && ! $model->declaresMethod('newFactory')) {
             $lines[] = 'use HasFactory; (imported from Illuminate\Database\Eloquent\Factories)';
             $lines[] = "protected static function newFactory(): {$this->aggregate}Factory { return {$this->aggregate}Factory::new(); }";
         }
@@ -195,7 +196,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
         if ($this->files->isDirectory($application)) {
             foreach ($this->files->allFiles($application) as $file) {
-                if (str_contains($file->getContents(), 'publishDomainEvents')) {
+                if (SourceFile::at($file->getPathname())->calls('publishDomainEvents')) {
                     return;
                 }
             }
@@ -228,17 +229,25 @@ final class MakeAggregateCommand extends ScaffoldCommand
         // follows: bootRoutes() applies the middleware group but no prefix.
         $route = fn (string $name): string => "Route::get('/{$slug}/{id}', [{$this->aggregate}Controller::class, 'show'])->name('{$name}');";
 
+        $controller = "App\\{$this->context}\\{$this->plural}\\Infrastructure\\Http\\Controllers\\{$this->aggregate}Controller";
+
         $snippets = [
-            'web' => [$route("{$slug}.show")],
+            'web' => [
+                'controller' => $controller,
+                'lines' => [$route("{$slug}.show")],
+            ],
             'api' => [
-                "Route::prefix('api')->group(function () {",
-                '    '.$route("api.{$slug}.show"),
-                '});',
-                "// the {$this->aggregate}Controller here is the one under Http\\Controllers\\API",
+                'controller' => "App\\{$this->context}\\{$this->plural}\\Infrastructure\\Http\\Controllers\\API\\{$this->aggregate}Controller",
+                'lines' => [
+                    "Route::prefix('api')->group(function () {",
+                    '    '.$route("api.{$slug}.show"),
+                    '});',
+                    "// the {$this->aggregate}Controller here is the one under Http\\Controllers\\API",
+                ],
             ],
         ];
 
-        foreach ($snippets as $kind => $lines) {
+        foreach ($snippets as $kind => $snippet) {
             if (! $this->wants($kind)) {
                 continue;
             }
@@ -249,15 +258,17 @@ final class MakeAggregateCommand extends ScaffoldCommand
             // A developer who has declared the route may well have put it
             // behind middleware, and pasting the canonical one back replaces
             // it: RouteCollection keys by method and URI.
-            if ($this->files->exists($file)
-                && str_contains($this->files->get($file), "{$this->aggregate}Controller")) {
+            //
+            // Asked by its full name, which is what tells the web controller
+            // from the one under API: they share a short name.
+            if (SourceFile::at($file)->references($snippet['controller'])) {
                 continue;
             }
 
             $this->newLine();
             $this->line("  Add to <options=bold>{$this->relative($file)}</>:");
 
-            foreach ($lines as $line) {
+            foreach ($snippet['lines'] as $line) {
                 $this->line("  <fg=gray>{$line}</>");
             }
 
@@ -280,9 +291,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
     private function tableDeclaredIn(string $model): ?string
     {
-        return preg_match('/protected \$table = \'([^\']+)\';/', $this->files->get($model), $matches) === 1
-            ? $matches[1]
-            : null;
+        return SourceFile::at($model)->propertyString('table');
     }
 
     /**
@@ -415,25 +424,32 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
         $contents = $this->files->get($file);
 
-        // Matching the generated line verbatim would miss a reformatted or
-        // re-indented provider and append the binding a second time, silently
-        // overriding whatever the first one pointed at.
-        $alreadyBound = preg_match(
-            '/\b'.preg_quote("{$this->aggregate}Repository", '/').'::class\s*=>/',
-            $contents
-        ) === 1;
+        // Asked of the declaration itself: matching the generated line would
+        // miss a reformatted provider and append the binding a second time,
+        // silently overriding whatever the first one pointed at, while
+        // matching the text alone would count one left in a comment.
+        $declared = SourceFile::at($file);
 
-        if (! $alreadyBound) {
+        // Unreadable is not the same as empty: taking it as empty binds the
+        // repository a second time and registers the migration path again.
+        if (! $declared->parsed()) {
+            $this->components->twoColumnDetail($this->relative($file), '<fg=red>could not be read</>');
+            $this->components->warn("{$this->context}ServiceProvider does not parse. Fix it, then run this again.");
+
+            return false;
+        }
+
+        if (! in_array($contract, $declared->propertyKeys('bindings'), true)) {
             $contents = $this->withImport($contents, $contract);
             $contents = $contents === null ? null : $this->withImport($contents, $eloquent);
             $contents = $contents === null ? null : $this->appendToArray($contents, 'bindings', $binding);
         }
 
         if ($contents !== null && $this->wants('migration')) {
-            $entry = "        __DIR__.'/{$this->plural}/Infrastructure/Persistence/Migrations',";
+            $path = "/{$this->plural}/Infrastructure/Persistence/Migrations";
 
-            if (! str_contains($contents, $entry)) {
-                $contents = $this->appendToArray($contents, 'migrations', $entry);
+            if (! in_array($path, $declared->propertyStrings('migrations'), true)) {
+                $contents = $this->appendToArray($contents, 'migrations', "        __DIR__.'{$path}',");
             }
         }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Console\Commands;
 
+use App\Shared\Infrastructure\Console\Support\SourceFile;
+
 /**
  * Class MakeBoundedContextCommand
  *
@@ -157,16 +159,21 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
         $contents = $this->files->get($file);
         $class = "App\\{$context}\\{$context}ServiceProvider";
 
-        // Both shapes count as registered: Laravel's own providers.php lists
-        // classes fully qualified, while this command adds an import and the
-        // short name. Matching the bare class name would also match the
-        // import, so a run that added the import but never reached the list
-        // would report itself as already registered for ever after; the
-        // lookbehind keeps Probe from matching SubProbeServiceProvider.
-        $registered = str_contains($contents, $class.'::class')
-            || preg_match('/(?<![\w\\\\])'.preg_quote($context, '/').'ServiceProvider::class/', $contents) === 1;
+        // Asked of the array itself. Laravel's own providers.php lists classes
+        // fully qualified and this command adds an import and the short name;
+        // resolved through the file's imports both name the same class, and
+        // neither an import on its own nor a mention in a comment counts.
 
-        if ($registered) {
+        $listed = SourceFile::at($file);
+
+        if (! $listed->parsed()) {
+            $this->components->twoColumnDetail('bootstrap/providers.php', '<fg=red>could not be read</>');
+            $this->components->warn("bootstrap/providers.php does not parse. Register {$class} once it does.");
+
+            return false;
+        }
+
+        if (in_array($class, $listed->returnedClasses(), true)) {
             $this->components->twoColumnDetail('bootstrap/providers.php', '<fg=yellow>already registered</>');
 
             return true;

--- a/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Console\Commands;
 
+use App\Shared\Infrastructure\Console\Support\SourceFile;
+
 /**
  * Class MakeEventHandlerCommand
  *
@@ -63,11 +65,25 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
         // literal silently drops the earlier one. Checked before anything is
         // written, so a refusal leaves no orphan handler behind.
         //
-        // Comments are stripped first: a mapping somebody parked behind // is
-        // not a mapping, and would otherwise block the command outright.
-        $declared = (string) preg_replace('#/\*.*?\*/|//[^\n]*#s', '', $contents);
+        // Asked of the declared keys: a mapping somebody parked behind // is
+        // not a mapping, and blocked the command outright when this was a
+        // search over the text.
+        $eventClass = "App\\{$target['context']}\\{$target['plural']}\\Domain\\Events\\{$event}";
+        $declared = SourceFile::at($provider);
 
-        if (preg_match('/(?<![\w\\\\])'.preg_quote($event, '/').'::class\s*=>/', $declared) === 1) {
+        // Unreadable is not the same as empty. Treating it as empty here would
+        // add a second entry under a key that already has one, which is the
+        // exact silent loss this guard exists to prevent.
+        if (! $declared->parsed()) {
+            $this->components->error("{$target['context']}ServiceProvider does not parse, so its \$events cannot be read.");
+            $this->components->bulletList([
+                'Fix the provider first: a second entry under one key drops the first without a word.',
+            ]);
+
+            return self::FAILURE;
+        }
+
+        if (in_array($eventClass, $declared->propertyKeys('events'), true)) {
             $this->components->error("[{$event}] is already handled in {$target['context']}ServiceProvider.");
             $this->components->bulletList([
                 'Declare the second handler by hand: PHP would drop one of two entries under the same key.',
@@ -109,7 +125,7 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
      */
     private function printQueuedHint(string $file, string $name): void
     {
-        if (str_contains($this->files->get($file), 'ShouldQueue')) {
+        if (SourceFile::at($file)->implementsInterface('Illuminate\\Contracts\\Queue\\ShouldQueue')) {
             return;
         }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Console\Commands;
 
+use App\Shared\Infrastructure\Console\Support\SourceFile;
 use Illuminate\Support\Str;
 
 /**
@@ -83,7 +84,7 @@ final class MakeUseCaseCommand extends ScaffoldCommand
 
         if ($this->files->isDirectory($application)) {
             foreach ($this->files->allFiles($application) as $file) {
-                if (str_contains($file->getContents(), 'publishDomainEvents')) {
+                if (SourceFile::at($file->getPathname())->calls('publishDomainEvents')) {
                     return;
                 }
             }

--- a/app/Shared/Infrastructure/Console/Support/SourceFile.php
+++ b/app/Shared/Infrastructure/Console/Support/SourceFile.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Console\Support;
+
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+
+/**
+ * Class SourceFile
+ *
+ * Answers questions about a PHP file for the scaffolding commands.
+ *
+ * They used to ask by searching the text, which cannot tell a call from a
+ * mention of the same name in a comment, a docblock or a string. That is not
+ * a theoretical difference: a mapping somebody had parked behind // was
+ * enough to refuse a command outright.
+ *
+ * Class names come back fully qualified, resolved through the file's own
+ * imports, so a comparison never has to guess which of the two forms was
+ * written.
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+final class SourceFile
+{
+    private static ?Parser $parser = null;
+
+    /** @var array<int, Node> */
+    private readonly array $ast;
+
+    private readonly NodeFinder $finder;
+
+    private readonly bool $parsed;
+
+    /**
+     * A file that does not parse answers no to everything, and says so
+     * through parsed().
+     *
+     * The difference matters. Answering "no" is right for a hint, which at
+     * worst repeats advice; it is wrong for a guard against writing something
+     * twice, where "I could not read it" and "it is not there" lead to
+     * opposite decisions.
+     */
+    private function __construct(string $code)
+    {
+        $this->finder = new NodeFinder;
+
+        try {
+            $ast = self::parser()->parse($code) ?? [];
+            $parsed = true;
+        } catch (Error) {
+            $ast = [];
+            $parsed = false;
+        }
+
+        $this->parsed = $parsed;
+
+        $traverser = new NodeTraverser(new NameResolver);
+
+        $this->ast = $traverser->traverse($ast);
+    }
+
+    public static function at(string $path): self
+    {
+        return new self(is_file($path) ? (string) file_get_contents($path) : '');
+    }
+
+    public static function of(string $code): self
+    {
+        return new self($code);
+    }
+
+    /**
+     * Whether the file could be read at all. A missing file parses fine and
+     * simply holds nothing; only a syntax error answers false.
+     */
+    public function parsed(): bool
+    {
+        return $this->parsed;
+    }
+
+    /**
+     * Whether any method with this name is called anywhere in the file.
+     */
+    public function calls(string $method): bool
+    {
+        return $this->finder->findFirst(
+            $this->ast,
+            fn (Node $node): bool => ($node instanceof Node\Expr\MethodCall
+                || $node instanceof Node\Expr\NullsafeMethodCall
+                || $node instanceof Node\Expr\StaticCall)
+                && $node->name instanceof Node\Identifier
+                && $node->name->toString() === $method
+        ) !== null;
+    }
+
+    /**
+     * Whether a class in the file declares this method.
+     */
+    public function declaresMethod(string $method): bool
+    {
+        return $this->finder->findFirst(
+            $this->ast,
+            fn (Node $node): bool => $node instanceof Node\Stmt\ClassMethod
+                && $node->name->toString() === $method
+        ) !== null;
+    }
+
+    /**
+     * Whether the file names this class anywhere it counts as a reference.
+     */
+    public function references(string $class): bool
+    {
+        return $this->finder->findFirst(
+            $this->ast,
+            fn (Node $node): bool => $node instanceof Node\Expr\ClassConstFetch
+                && $node->class instanceof Node\Name
+                && $node->class->toString() === ltrim($class, '\\')
+        ) !== null;
+    }
+
+    /**
+     * Whether a class in the file implements this interface.
+     *
+     * An implements clause is a name, not a ::class reference, so references()
+     * never sees it.
+     */
+    public function implementsInterface(string $interface): bool
+    {
+        return $this->finder->findFirst(
+            $this->ast,
+            function (Node $node) use ($interface): bool {
+                if (! $node instanceof Node\Stmt\Class_) {
+                    return false;
+                }
+
+                foreach ($node->implements as $name) {
+                    if ($name->toString() === ltrim($interface, '\\')) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        ) !== null;
+    }
+
+    /**
+     * The literal string a property is initialised with, e.g. $table.
+     */
+    public function propertyString(string $property): ?string
+    {
+        $default = $this->propertyDefault($property);
+
+        return $default instanceof Node\Scalar\String_ ? $default->value : null;
+    }
+
+    /**
+     * The class names used as keys of an array property, e.g. $events.
+     *
+     * @return list<string>
+     */
+    public function propertyKeys(string $property): array
+    {
+        return $this->arrayItems($property, fn (Node\ArrayItem $item): ?string => $item->key instanceof Node\Expr\ClassConstFetch
+            && $item->key->class instanceof Node\Name
+                ? $item->key->class->toString()
+                : null);
+    }
+
+    /**
+     * The string parts of an array property's values, which is how the
+     * migration paths are written: __DIR__.'/Invoices/…/Migrations'.
+     *
+     * @return list<string>
+     */
+    public function propertyStrings(string $property): array
+    {
+        return $this->arrayItems($property, function (Node\ArrayItem $item): ?string {
+            if ($item->value instanceof Node\Scalar\String_) {
+                return $item->value->value;
+            }
+
+            return $item->value instanceof Node\Expr\BinaryOp\Concat
+                && $item->value->right instanceof Node\Scalar\String_
+                    ? $item->value->right->value
+                    : null;
+        });
+    }
+
+    /**
+     * The class names listed in the array the file returns, which is the
+     * shape of bootstrap/providers.php.
+     *
+     * @return list<string>
+     */
+    public function returnedClasses(): array
+    {
+        $return = $this->finder->findFirstInstanceOf($this->ast, Node\Stmt\Return_::class);
+
+        if (! $return?->expr instanceof Node\Expr\Array_) {
+            return [];
+        }
+
+        $classes = [];
+
+        foreach ($return->expr->items as $item) {
+            if ($item->value instanceof Node\Expr\ClassConstFetch && $item->value->class instanceof Node\Name) {
+                $classes[] = $item->value->class->toString();
+            }
+        }
+
+        return $classes;
+    }
+
+    /**
+     * @param  callable(Node\ArrayItem): ?string  $read
+     * @return list<string>
+     */
+    private function arrayItems(string $property, callable $read): array
+    {
+        $default = $this->propertyDefault($property);
+
+        if (! $default instanceof Node\Expr\Array_) {
+            return [];
+        }
+
+        $found = [];
+
+        foreach ($default->items as $item) {
+            if (($value = $read($item)) !== null) {
+                $found[] = $value;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * One statement can declare several properties — `protected array $a = [],
+     * $b = [];` — so the one asked for is not always the first.
+     */
+    private function propertyDefault(string $property): ?Node\Expr
+    {
+        foreach ($this->finder->findInstanceOf($this->ast, Node\Stmt\Property::class) as $statement) {
+            foreach ($statement->props as $declared) {
+                if ($declared->name->toString() === $property) {
+                    return $declared->default;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static function parser(): Parser
+    {
+        return self::$parser ??= (new ParserFactory)->createForNewestSupportedVersion();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
         "mobiledetect/mobiledetectlib": "^4.8",
+        "nikic/php-parser": "^5.8",
         "othercode/laravel-version": "^0.3",
         "tightenco/ziggy": "^2.0"
     },

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -326,7 +326,9 @@ test('it stays quiet when the application layer already publishes', function () 
 
     $application = app_path('ScaffoldFixture/Widgets/Application');
     File::ensureDirectoryExists($application);
-    File::put("{$application}/CreateWidget.php", "<?php\n\n// \$widget->publishDomainEvents(\$this->eventBus);\n");
+    // A real call, not a mention of one: the command reads this file rather
+    // than searching it, so a commented line would not count and should not.
+    File::put("{$application}/CreateWidget.php", "<?php\n\n\$widget->publishDomainEvents(\$this->eventBus);\n");
 
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
         ->doesntExpectOutputToContain('Nothing publishes WidgetCreated.')
@@ -340,7 +342,17 @@ test('it does not re-advise a route the file already declares', function () {
 
     $routes = app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes');
     File::ensureDirectoryExists($routes);
-    File::put("{$routes}/web.php", "<?php\n\nRoute::middleware('auth')->get('/widgets/{id}', [WidgetController::class, 'show'])->name('widgets.show');\n");
+    // Imported, the way a route file that actually loads has to be: without
+    // the use statement WidgetController::class means the global one, and
+    // the command is right to say the controller is not wired here.
+    File::put("{$routes}/web.php", implode("\n", [
+        '<?php',
+        '',
+        'use App\ScaffoldFixture\Widgets\Infrastructure\Http\Controllers\WidgetController;',
+        '',
+        "Route::middleware('auth')->get('/widgets/{id}', [WidgetController::class, 'show'])->name('widgets.show');",
+        '',
+    ]));
 
     // Pasting the canonical route back replaces the customised one, since
     // RouteCollection keys by method and URI, and the auth middleware is
@@ -417,6 +429,56 @@ test('it hints a distinct route for the api controller', function () {
         ->expectsOutputToContain("Route::prefix('api')->group(function () {")
         ->expectsOutputToContain("Route::get('/widgets/{id}', [WidgetController::class, 'show'])->name('api.widgets.show');")
         ->assertSuccessful();
+});
+
+test('it does not register the migration path twice', function () {
+    $args = ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true];
+
+    $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
+    $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
+
+    // A second entry would load the same directory twice.
+    expect(substr_count(
+        File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')),
+        "__DIR__.'/Widgets/Infrastructure/Persistence/Migrations'"
+    ))->toBe(1);
+});
+
+test('it recognises a migration path however the provider is formatted', function () {
+    $args = ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true];
+    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+
+    $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
+
+    // The entry is read from the declaration, not matched as a formatted line,
+    // so re-indenting it no longer hides it and earn a duplicate.
+    File::put($provider, str_replace(
+        "        __DIR__.'/Widgets/Infrastructure/Persistence/Migrations',",
+        "            __DIR__ . '/Widgets/Infrastructure/Persistence/Migrations',",
+        File::get($provider)
+    ));
+
+    $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
+
+    expect(substr_count(File::get($provider), "/Widgets/Infrastructure/Persistence/Migrations'"))->toBe(1);
+});
+
+test('it refuses to wire into a provider that does not parse', function () {
+    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertSuccessful();
+
+    File::put($provider, str_replace(
+        'class ScaffoldFixtureServiceProvider',
+        'class ScaffoldFixtureServiceProvider(',
+        File::get($provider)
+    ));
+
+    // Reading it as empty would bind the repository a second time.
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
+        ->assertFailed();
+
+    expect(substr_count(File::get($provider), '=> EloquentWidgetRepository::class'))->toBe(1);
 });
 
 test('it fails when the context provider has nothing to wire', function () {

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -159,6 +159,46 @@ test('it does not claim to have created a handler it skipped', function () {
         ->assertSuccessful();
 });
 
+test('queued says nothing about a handler that is already queued', function () {
+    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting', '--queued' => true];
+
+    $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();
+
+    File::put($this->provider, str_replace(
+        '        WidgetCreated::class => NotifyAccounting::class,'."\n",
+        '',
+        File::get($this->provider)
+    ));
+
+    // The file is skipped either way; the difference is that this one already
+    // implements ShouldQueue, so there is nothing left to do by hand.
+    $this->artisan('ldd:make:event-handler', $args)
+        ->doesntExpectOutputToContain('already existed and was left as it is')
+        ->assertSuccessful();
+});
+
+test('it refuses to guess at a provider that does not parse', function () {
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
+    ])->assertSuccessful();
+
+    File::put($this->provider, str_replace(
+        'class ScaffoldFixtureServiceProvider',
+        'class ScaffoldFixtureServiceProvider(',
+        File::get($this->provider)
+    ));
+
+    // Reading it as empty would add a second entry under a key that already
+    // has one, and PHP keeps only the last: the first handler stops running
+    // with nothing said anywhere.
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'AlsoNotify',
+    ])->assertFailed();
+
+    expect(substr_count(File::get($this->provider), 'WidgetCreated::class =>'))->toBe(1)
+        ->and(app_path('ScaffoldFixture/Widgets/Application/EventHandlers/AlsoNotify.php'))->not->toBeFile();
+});
+
 test('it fails when the provider has no events array to declare in', function () {
     File::put($this->provider, "<?php\n\nnamespace App\ScaffoldFixture;\n\nuse ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;\n\nclass ScaffoldFixtureServiceProvider extends BoundedContextServiceProvider\n{\n}\n");
 

--- a/tests/Unit/Shared/SourceFileTest.php
+++ b/tests/Unit/Shared/SourceFileTest.php
@@ -1,0 +1,172 @@
+<?php
+
+use App\Shared\Infrastructure\Console\Support\SourceFile;
+
+/*
+ * Every case here is one the scaffolding commands used to get wrong by
+ * searching the text: a name in a comment, in a docblock or inside a string
+ * reads exactly like the real thing.
+ */
+
+test('it tells a call from a mention of the same name', function () {
+    $source = SourceFile::of(<<<'PHP'
+    <?php
+    class Widget
+    {
+        /** Call registerDomainEvent here when this grows up. */
+        public static function new(): self
+        {
+            // $widget->registerDomainEvent(...);
+            $note = 'remember to registerDomainEvent';
+
+            return new self;
+        }
+    }
+    PHP);
+
+    expect($source->calls('registerDomainEvent'))->toBeFalse();
+
+    expect(SourceFile::of('<?php $w->registerDomainEvent($e);')->calls('registerDomainEvent'))->toBeTrue();
+});
+
+test('it finds a declared method and ignores one only spoken about', function () {
+    $source = SourceFile::of(<<<'PHP'
+    <?php
+    class Widget
+    {
+        // protected static function newFactory(): WidgetFactory {}
+        public function other(): void {}
+    }
+    PHP);
+
+    expect($source->declaresMethod('newFactory'))->toBeFalse()
+        ->and($source->declaresMethod('other'))->toBeTrue();
+});
+
+test('it resolves class references through the imports', function () {
+    $source = SourceFile::of(<<<'PHP'
+    <?php
+    use App\Billing\Invoices\Infrastructure\Http\Controllers\InvoiceController;
+    Route::get('/invoices/{id}', [InvoiceController::class, 'show']);
+    PHP);
+
+    // Written short, asked for by its full name: the file's own use statement
+    // is what connects the two, and a substring search cannot follow it.
+    expect($source->references('App\Billing\Invoices\Infrastructure\Http\Controllers\InvoiceController'))->toBeTrue()
+        ->and($source->references('App\Billing\Invoices\Infrastructure\Http\Controllers\OtherController'))->toBeFalse();
+});
+
+test('it sees an implements clause, which is not a class reference', function () {
+    $queued = SourceFile::of(<<<'PHP'
+    <?php
+    use Illuminate\Contracts\Queue\ShouldQueue;
+    final readonly class NotifyAccounting implements ShouldQueue {}
+    PHP);
+
+    $plain = SourceFile::of(<<<'PHP'
+    <?php
+    use Illuminate\Contracts\Queue\ShouldQueue;
+    final readonly class NotifyAccounting {}
+    PHP);
+
+    // The second file imports the interface without implementing it, which is
+    // exactly the half-done state a run left behind before.
+    expect($queued->implementsInterface('Illuminate\Contracts\Queue\ShouldQueue'))->toBeTrue()
+        ->and($plain->implementsInterface('Illuminate\Contracts\Queue\ShouldQueue'))->toBeFalse();
+});
+
+test('it finds a call made through the nullsafe operator', function () {
+    expect(SourceFile::of('<?php $w?->publishDomainEvents($bus);')->calls('publishDomainEvents'))->toBeTrue();
+});
+
+test('it finds a property that is not the first of its statement', function () {
+    // One statement, two properties: asking for the second used to answer as
+    // if it were not declared at all.
+    $source = SourceFile::of('<?php class W { protected $guarded = [], $table = "widgets"; }');
+
+    expect($source->propertyString('table'))->toBe('widgets');
+});
+
+test('it reads the table a model declares', function () {
+    expect(SourceFile::of('<?php class W { protected $table = "widgets"; }')->propertyString('table'))->toBe('widgets')
+        ->and(SourceFile::of('<?php class W {}')->propertyString('table'))->toBeNull();
+});
+
+test('it lists the keys of an array property and skips commented ones', function () {
+    $source = SourceFile::of(<<<'PHP'
+    <?php
+    namespace App\Billing;
+    use App\Billing\Invoices\Domain\Events\InvoiceCreated;
+    class BillingServiceProvider
+    {
+        protected array $events = [
+            InvoiceCreated::class => NotifyAccounting::class,
+            // InvoicePaid::class => Ghost::class,
+        ];
+    }
+    PHP);
+
+    // The commented entry is what refused the command outright before.
+    expect($source->propertyKeys('events'))
+        ->toBe(['App\Billing\Invoices\Domain\Events\InvoiceCreated']);
+});
+
+test('it reads the migration paths out of a concatenation', function () {
+    $source = SourceFile::of(<<<'PHP'
+    <?php
+    class P
+    {
+        protected array $migrations = [
+            __DIR__.'/Invoices/Infrastructure/Persistence/Migrations',
+        ];
+    }
+    PHP);
+
+    expect($source->propertyStrings('migrations'))
+        ->toBe(['/Invoices/Infrastructure/Persistence/Migrations']);
+});
+
+test('it lists returned providers however they are written', function () {
+    $qualified = SourceFile::of(<<<'PHP'
+    <?php
+    return [
+        App\Shared\SharedServiceProvider::class,
+    ];
+    PHP);
+
+    $imported = SourceFile::of(<<<'PHP'
+    <?php
+    use App\Shared\SharedServiceProvider;
+    return [
+        SharedServiceProvider::class,
+    ];
+    PHP);
+
+    // Laravel generates the first shape and the commands write the second.
+    // Both name the same class, which is the whole point of resolving.
+    expect($qualified->returnedClasses())->toBe(['App\Shared\SharedServiceProvider'])
+        ->and($imported->returnedClasses())->toBe(['App\Shared\SharedServiceProvider']);
+});
+
+test('it says whether it could read the file at all', function () {
+    // "I could not read it" and "it is not there" lead to opposite decisions
+    // in a guard against writing something twice.
+    expect(SourceFile::of('<?php class Broken {')->parsed())->toBeFalse()
+        ->and(SourceFile::of('<?php class Fine {}')->parsed())->toBeTrue()
+        ->and(SourceFile::at('/no/such/file.php')->parsed())->toBeTrue();
+});
+
+test('a file that does not parse answers no to everything', function () {
+    $source = SourceFile::of('<?php class Broken {');
+
+    expect($source->calls('anything'))->toBeFalse()
+        ->and($source->declaresMethod('anything'))->toBeFalse()
+        ->and($source->references('Anything'))->toBeFalse()
+        ->and($source->propertyString('table'))->toBeNull()
+        ->and($source->propertyKeys('events'))->toBe([])
+        ->and($source->returnedClasses())->toBe([]);
+});
+
+test('a file that is not there answers no to everything', function () {
+    expect(SourceFile::at('/no/such/file.php')->returnedClasses())->toBe([]);
+});


### PR DESCRIPTION
Ten decisions in the scaffolding commands were taken by scanning source text, which cannot tell a call from a mention of the same name in a comment, a docblock or a string. A mapping parked behind `//` was enough to refuse a command outright.

`SourceFile` parses once and answers exactly, resolving class names through the file's own imports so Laravel's fully qualified provider style and the short form these commands write name the same class. It also separates "nothing is there" from "I could not read this": taking an unparseable provider as empty is right for a hint and wrong for a guard against writing twice.

Reading only — the writing side stays as it is, since `printFormatPreserving` collapses the multiline array in `bootstrap/providers.php` onto one line.

Closes #69