### PR TITLE
docs: #62 bring the README up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,10 +242,10 @@ app
     └── Users
 ```
 
-An aggregate has no fixed shape, and no layer is present in all of them. Across the 15 aggregates of the production
-application this starter grew from: 13 have `Domain`, 11 have `Infrastructure`, 10 have `Application` and 5 have
-`Domain/Events`. That is why `ldd:make:bounded-context` creates no layer directories at all, and why
-`ldd:make:aggregate` generates a core and puts the rest behind flags.
+An aggregate has no fixed shape. The two shipped here make the point: `Users` has all three layers, plus contracts,
+events, exceptions and event handlers, while `APITokens` is one model and one migration. That is why
+`ldd:make:bounded-context` creates no layer directories at all, and why `ldd:make:aggregate` generates a core and
+puts the rest behind flags.
 
 Each module follows a 3-layer architecture:
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ one aggregate at a time:
 ```
 
 That writes the aggregate root, its repository contract and Eloquent implementation, and its
-exceptions — then binds the repository in the context's service provider, which is what makes it
+exceptions. It then binds the repository in the context's service provider, which is what makes it
 resolvable at all. Everything else is opt in, because real aggregates rarely need every layer:
 
 | Flag | Adds |
@@ -182,13 +182,13 @@ recorded events inside the same transaction, so a failing listener cannot leave 
 persisted. Without it the events pile up on the instance and vanish with it.
 
 The handler is the one that needs wiring. It is declared in the provider's `$events`, and one that
-is missing from there is simply never called — which is why the command refuses to add a second
+is missing from there is simply never called. That is why the command refuses to add a second
 handler for an event that already has one, rather than leave two entries under a key where PHP
 keeps only the last.
 
 All four commands only ever add. Run one again with a flag you skipped and it writes what is missing,
-leaves every file already on disk alone — your migration may have been applied, and the provider
-carries wiring no stub knows about — and prints the lines to add by hand.
+leaves every file already on disk alone, since your migration may have been applied and the provider
+carries wiring no stub knows about, and prints the lines to add by hand.
 
 ## 📁 Structure
 
@@ -216,7 +216,7 @@ app
     └── SharedServiceProvider.php
 ```
 
-A context's own `Shared` directory holds what its aggregates have in common — its route files live there. The
+A context's own `Shared` directory holds what its aggregates have in common, such as its route files. The
 top-level `Shared` is the application's foundation layer rather than a bounded context: it owns the scaffolding
 commands, the Inertia base controller, middleware and the cache and jobs migrations, and it is the one place
 `ldd:make:aggregate` refuses to write into.
@@ -336,7 +336,7 @@ app
                 └── UserFactory.php
 ```
 
-Migrations belong to the aggregate that owns the table, not to `database/migrations` — which this starter does not
+Migrations belong to the aggregate that owns the table, not to `database/migrations`, which this starter does not
 have. Each one is registered through the `$migrations` array on the context's provider, and forgetting that entry is
 the quiet failure `ldd:make:aggregate --migration` exists to prevent.
 
@@ -361,7 +361,7 @@ and the architecture rules exempt it by detecting `newFactory` rather than listi
 
 **Domain events are ComplexHeart's, not Laravel's.** They implement `ComplexHeart\Domain\Contracts\Events\Event` and
 use the `IsDomainEvent` trait, which supplies `eventId`, `eventName`, `payload` and `occurredOn`. They carry
-identifiers and scalars, never Eloquent models — which is what makes `payload()` meaningful and `SerializesModels`
+identifiers and scalars, never Eloquent models. That is what makes `payload()` meaningful and `SerializesModels`
 unnecessary. An aggregate records them; a use case publishes them through the `EventBus`.
 
 ## ⚠️ Disclaimer

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Using **Laravel Domain Driven** helps you build clean, flexible, and long-lastin
 
 ## ✨ Features
 
-**Laravel Domain Driven** includes the core features provided by **Laravel Jetstream**, but organized using 
-**Domain-Driven Design (DDD)** and **Hexagonal Architecture**. Key features include:
+The user-facing features started life as **Laravel Jetstream** scaffolding, but Jetstream itself is not a dependency:
+what is here is **Laravel Fortify** and **Inertia**, rearranged into **Domain-Driven Design (DDD)** and **Hexagonal
+Architecture**. Key features include:
 
 - **Authentication**: User registration, login, password reset, email verification, and more, powered by **Laravel
   Fortify**.
-- **Authorization**: Role-based access control with user roles and permissions.
 - **Two-Factor Authentication (2FA)**: Extra layer of security for user accounts, integrated with **Laravel Fortify**.
 - **Session Management**: Manage active sessions and log users out of other devices.
 - **Profile Management**: Users can update their profile information, including email and password.
@@ -52,10 +52,12 @@ Using **Laravel Domain Driven** helps you build clean, flexible, and long-lastin
   interactive UIs, while still leveraging the full power of Laravel on the backend.
 - **Tailwind CSS**: Utility-first CSS framework that makes it easy to create responsive and customized designs without
   writing custom CSS.
-- **Laravel Sanctum**: Simple token-based API authentication system, allowing you to securely authenticate and manage
-  user sessions for SPAs and mobile applications.
+- **Laravel Sanctum**: Session authentication for the Inertia front end, and API tokens through the `APITokens`
+  aggregate, which replaces Sanctum's own model so tokens can belong to a uuid user.
+- **ComplexHeart**: Domain events and the declarative bounded context provider both come from
+  [complex-heart/on-laravel](https://github.com/ComplexHeart/on-laravel).
 - **Laravel Sail**: Lightweight Docker environment for developing Laravel applications locally, simplifying setup and
-  development.
+  development. It is the supported way to run this project, with PHP 8.4 and Node 24 pinned in `docker-compose.yml`.
 - **Laravel Pint**: A zero-config PSR-12 compliant PHP code style fixer, ensuring consistent coding standards across
   your project.
 - **Larastan**: Static analysis tool that helps detect potential issues in your code, improving code quality and
@@ -89,7 +91,9 @@ Once installed, start the application with the following commands:
 # Run database migrations
 ./vendor/bin/sail artisan migrate
 
-# Install frontend dependencies and build assets
+# Install frontend dependencies and build assets. Node 24 comes from the Sail
+# image, pinned by NODE_VERSION in docker-compose.yml; .nvmrc matches it for
+# anything you run on the host instead.
 ./vendor/bin/sail npm install
 ./vendor/bin/sail npm run build
 
@@ -106,8 +110,23 @@ Once installed, start the application with the following commands:
 For development with HMR, queue worker, and log tailing:
 
 ```bash
-composer dev
+./vendor/bin/sail up -d
+./vendor/bin/sail npm run dev          # Vite, with HMR on 5173
+./vendor/bin/sail artisan queue:listen --tries=1
+./vendor/bin/sail artisan pail --timeout=0
 ```
+
+There is also a `composer dev` script that runs the four at once, but it calls `php` and `npm` directly, so it needs
+them on your host. Sail is what this project supports.
+
+Deploying a rebuilt front end needs one more step:
+
+```bash
+./vendor/bin/sail artisan view:clear
+```
+
+Inertia 3 reads the page payload from `<script data-page>`. A cached Blade view still serving the Inertia 2
+`<div data-page="{json}">` markup leaves the application unhydrated, with no error anywhere to say why.
 
 ## 🛠️ Scaffolding
 
@@ -187,24 +206,46 @@ service provider. For example:
 ```
 app
 ├── IdentityAndAccess
-│   └── IdentityAndAccessServiceProvider.php
+│   ├── APITokens
+│   ├── IdentityAndAccessServiceProvider.php
+│   ├── Shared
+│   └── Users
 └── Shared
+    ├── Domain
+    ├── Infrastructure
     └── SharedServiceProvider.php
 ```
+
+A context's own `Shared` directory holds what its aggregates have in common — its route files live there. The
+top-level `Shared` is the application's foundation layer rather than a bounded context: it owns the scaffolding
+commands, the Inertia base controller, middleware and the cache and jobs migrations, and it is the one place
+`ldd:make:aggregate` refuses to write into.
 
 Each context is divided into **modules**, with each module representing an aggregate root. An aggregate root is a group
 of related information and behaviors that work together as a single unit. For example:
 
-* 👤 **User**: Contains all information and logic related to users, such as authentication, profile, and roles.
-* 🛒 **Order**: Manages the order details, status, and so on.
+* 👤 **User**: Contains all information and logic related to users, such as authentication, profile and sessions.
+* 🔑 **APIToken**: The Sanctum personal access token, owned by the context so it can belong to a uuid user.
 * 💳 **Invoice**: Represents the invoicing process, including item details, totals, and payment status.
 
 ```
 app
 └── IdentityAndAccess
+    ├── APITokens
     ├── IdentityAndAccessServiceProvider.php
+    ├── Shared
+    │   └── Infrastructure
+    │       └── Http
+    │           └── Routes
+    │               ├── api.php
+    │               └── web.php
     └── Users
 ```
+
+An aggregate has no fixed shape, and no layer is present in all of them. Across the 15 aggregates of the production
+application this starter grew from: 13 have `Domain`, 11 have `Infrastructure`, 10 have `Application` and 5 have
+`Domain/Events`. That is why `ldd:make:bounded-context` creates no layer directories at all, and why
+`ldd:make:aggregate` generates a core and puts the rest behind flags.
 
 Each module follows a 3-layer architecture:
 
@@ -289,11 +330,39 @@ app
             │       └── UserProfilePhotoController.php
             └── Persistence
                 ├── EloquentUserRepository.php
+                ├── Migrations
+                │   ├── 0000_00_00_000001_create_users_table.php
+                │   └── 2024_12_04_123046_add_two_factor_columns_to_users_table.php
                 └── UserFactory.php
 ```
 
+Migrations belong to the aggregate that owns the table, not to `database/migrations` — which this starter does not
+have. Each one is registered through the `$migrations` array on the context's provider, and forgetting that entry is
+the quiet failure `ldd:make:aggregate --migration` exists to prevent.
+
 This structure ensures that each part of the application is clearly defined, maintainable, and focused on its specific
 domain, while following DDD and Hexagonal Architecture principles.
+
+## 📐 Conventions
+
+Four things surprise people arriving from stock Laravel.
+
+**`routes/web.php` is empty on purpose.** Each context publishes its own routes through the `$routes` array on its
+provider, from `{Context}/Shared/Infrastructure/Http/Routes/`. `BoundedContextServiceProvider::bootRoutes()` applies
+the middleware group but *not* a URI prefix, so an `api.php` declares `Route::prefix('api')` itself.
+
+**Aggregates are identified by uuid.** A domain event carries the identifier, so the identifier has to exist before
+`save()`. `new()` assigns it up front with `HasUuids::newUniqueId()`, the same helper Eloquent's `creating` hook would
+have called later.
+
+**The aggregate root points at its own factory.** A factory living in `Infrastructure/Persistence` is not where
+Laravel looks for one, so the model declares `newFactory()`. That is a deliberate Domain to Infrastructure coupling,
+and the architecture rules exempt it by detecting `newFactory` rather than listing classes by hand.
+
+**Domain events are ComplexHeart's, not Laravel's.** They implement `ComplexHeart\Domain\Contracts\Events\Event` and
+use the `IsDomainEvent` trait, which supplies `eventId`, `eventName`, `payload` and `occurredOn`. They carry
+identifiers and scalars, never Eloquent models — which is what makes `payload()` meaningful and `SerializesModels`
+unnecessary. An aggregate records them; a use case publishes them through the `EventBus`.
 
 ## ⚠️ Disclaimer
 

--- a/app/IdentityAndAccess/Shared/Infrastructure/Http/Routes/api.php
+++ b/app/IdentityAndAccess/Shared/Infrastructure/Http/Routes/api.php
@@ -4,7 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 // The api middleware group is applied by the service provider, but the URI
-// prefix is not — BoundedContextServiceProvider::bootRoutes() only groups by
+// prefix is not. BoundedContextServiceProvider::bootRoutes() only groups by
 // middleware, so each context declares its own prefix.
 Route::prefix('api')->middleware('auth:sanctum')->group(function () {
     Route::get('/user', fn (Request $request) => $request->user())->name('user');

--- a/app/IdentityAndAccess/Users/Domain/User.php
+++ b/app/IdentityAndAccess/Users/Domain/User.php
@@ -48,7 +48,7 @@ class User extends Authenticatable implements MustVerifyEmail
      * Creates a new User and registers the UserCreated domain event.
      *
      * The identifier is assigned up front so the event can carry it before
-     * the aggregate is persisted. A caller may supply its own id — it is set
+     * the aggregate is persisted. A caller may supply its own id, which is set
      * explicitly rather than through $fillable, so mass assignment is never
      * a way to choose an identifier.
      *

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -65,7 +65,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
         // The table name is interpolated into the model's $table property and
         // into Schema::create(), so a quote or a space in it produces two
-        // files that do not parse — and the migrations path is registered as a
+        // files that do not parse. The migrations path is registered as a
         // directory, which takes `migrate` down with it.
         if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $this->table) !== 1) {
             $this->components->error("The table name must be a valid identifier, [{$this->table}] is not.");
@@ -183,7 +183,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
      * in this application that is the job of a use case: the repository only
      * persists. Nothing generated here closes that loop, and an event that is
      * never published fails the way everything else in these commands is
-     * built to prevent — silently.
+     * built to prevent: silently.
      */
     private function printEventHints(string $path): void
     {
@@ -412,7 +412,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
     /**
      * Binds the repository and, when a migration was generated, registers its
      * path. Without this the aggregate would resolve nothing and its tables
-     * would never be created — silently, in both cases.
+     * would never be created, silently in both cases.
      */
     private function wireProvider(): bool
     {

--- a/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
@@ -13,8 +13,8 @@ use Illuminate\Support\Str;
  * Adds a use case to an aggregate's Application layer.
  *
  * Nothing needs wiring: the container resolves the constructor by itself.
- * What this saves is the shape — a final readonly class that reaches the
- * domain only through the repository contract — and, with --publishes, the
+ * What this saves is the shape, a final readonly class that reaches the
+ * domain only through the repository contract, and, with --publishes, the
  * one idiom that is easy to leave out and impossible to notice missing.
  *
  * @author Unay Santisteban <usantisteban@othercode.io>

--- a/app/Shared/Infrastructure/Console/Support/SourceFile.php
+++ b/app/Shared/Infrastructure/Console/Support/SourceFile.php
@@ -244,8 +244,8 @@ final class SourceFile
     }
 
     /**
-     * One statement can declare several properties — `protected array $a = [],
-     * $b = [];` — so the one asked for is not always the first.
+     * One statement can declare several properties, as in `protected array
+     * $a = [], $b = [];`, so the one asked for is not always the first.
      */
     private function propertyDefault(string $property): ?Node\Expr
     {

--- a/stubs/bounded-context.routes.api.stub
+++ b/stubs/bounded-context.routes.api.stub
@@ -5,7 +5,7 @@
 |
 | Loaded by {{ context }}ServiceProvider through its $routes array. The api
 | middleware group is applied for you, but the URI prefix is not, so declare
-| it here — and keep the result distinct from every web route, because two
+| it here, and keep the result distinct from every web route, because two
 | routes sharing a method and a URI collapse into one:
 |
 |   use Illuminate\Support\Facades\Route;

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -129,7 +129,7 @@ arch('middleware has handle method')
 | on their own context or on Shared Domain. They must never reach into
 | another BC's internals or into Shared Infrastructure.
 |
-| The Shared context is a foundation layer — it must never reference
+| The Shared context is a foundation layer, so it must never reference
 | any specific bounded context.
 |
 | Adding a bounded context needs no change here: its rules are generated

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -487,7 +487,7 @@ test('it fails when the context provider has nothing to wire', function () {
     File::put($provider, "<?php\n\nnamespace App\ScaffoldFixture;\n\nuse ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;\n\nclass ScaffoldFixtureServiceProvider extends BoundedContextServiceProvider\n{\n}\n");
 
     // Reporting success would leave an aggregate whose repository contract
-    // resolves to nothing — the whole point of the wiring step.
+    // resolves to nothing, which is the whole point of the wiring step.
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
         ->assertFailed();
 

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -151,7 +151,7 @@ test('it does not claim to have created a handler it skipped', function () {
         File::get($this->provider)
     ));
 
-    // The run still does something worth reporting — it declares the mapping —
+    // The run still does something worth reporting, it declares the mapping,
     // but it did not create the handler and must not say it did.
     $this->artisan('ldd:make:event-handler', $args)
         ->expectsOutputToContain('exists, skipped')


### PR DESCRIPTION
The README advertised role-based access control with roles and permissions. There is no role column, no roles table, no policy and no gate anywhere. It also credited Jetstream for features while Jetstream is not a dependency — Fortify and Inertia are.

The structure had not kept up with the APITokens aggregate, per-context route directories, per-aggregate migrations or `app/Shared`, and nothing explained why `routes/web.php` is empty, why aggregates carry uuids, why the model points at its own factory, or that domain events come from ComplexHeart. Adds the `view:clear` deploy step too.

Every claim was checked against the code rather than carried over. That included my own figures on the issue: re-measuring icedlatte showed `Infrastructure` in 11 of 15 aggregates, not all 15, and none Infrastructure-only. Corrected in the comment thread and in the text.

Closes #62