### PR TITLE
fix: #72 run composer dev inside Sail

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,12 @@ Once installed, start the application with the following commands:
 For development with HMR, queue worker, and log tailing:
 
 ```bash
-./vendor/bin/sail up -d
-./vendor/bin/sail npm run dev          # Vite, with HMR on 5173
-./vendor/bin/sail artisan queue:listen --tries=1
-./vendor/bin/sail artisan pail --timeout=0
+composer dev
 ```
 
-There is also a `composer dev` script that runs the four at once, but it calls `php` and `npm` directly, so it needs
-them on your host. Sail is what this project supports.
+That runs the queue worker, the log tail and Vite together inside the Sail container, so Docker is the only thing it
+needs on your host. There is no `artisan serve` among them because the container already serves the application on
+`APP_PORT`, and Vite is reachable on `VITE_PORT` with HMR.
 
 Deploying a rebuilt front end needs one more step:
 

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "./vendor/bin/sail npx concurrently -c \"#c4b5fd,#fb7185,#fdba74\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=queue,logs,vite"
         ]
     },
     "extra": {


### PR DESCRIPTION
The `dev` script called `php` and `npm` on the host, in a project where Sail is the only supported environment. It now runs `concurrently` through Sail, so the queue worker, the log tail and Vite all start inside the container.

`artisan serve` is dropped: the container already serves the application, so it was a second web server on a different port.

Verified by running it: Vite answers on 5173 within a few seconds and concurrently reports all three processes.

Closes #72