### PR TITLE
feat: #67 publish aggregates through a resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,15 @@ resolvable at all. Everything else is opt in, because real aggregates rarely nee
 | `--factory` | A model factory, routed through the aggregate's `new()` |
 | `--events` | A `Created` domain event, recorded by `new()` and published by you |
 | `--requests` | A form request |
-| `--web` | An Inertia controller, rendering through `InertiaController` |
-| `--api` | An API controller |
+| `--web` | An Inertia controller, rendering through `InertiaController`, and a resource |
+| `--api` | An API controller, and a resource |
 | `--all` | All of the above |
+
+Either controller flag also writes an `{Aggregate}Resource`, because both of them publish and neither should hand
+out the model itself. It starts closed, with `id` and nothing else, so an attribute reaches the outside because you
+listed it rather than because a migration added it. The API controller returns the resource and Laravel wraps it in
+a `data` key; the Inertia controller passes `resolve($request)`, since the prop name is already the envelope there
+and Inertia would otherwise call `toArray()` directly, skipping the filtering that `when()` relies on.
 
 The table name defaults to the pluralised aggregate. Two contexts may each own an `Invoice`, but
 only one can create the `invoices` table, so `--table=billing_invoices` renames it for the second.

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -407,6 +407,13 @@ final class MakeAggregateCommand extends ScaffoldCommand
         if ($this->wants('api')) {
             $this->put("{$path}/Infrastructure/Http/Controllers/API/{$this->aggregate}Controller.php", $this->stub('aggregate.api-controller', $this->replacements()));
         }
+
+        // Both controllers publish through it, so it belongs to either flag.
+        // Neither should be handing out the model itself: everything on it
+        // would go over the wire, including whatever the next migration adds.
+        if ($this->wants('web') || $this->wants('api')) {
+            $this->put("{$path}/Infrastructure/Http/Resources/{$this->aggregate}Resource.php", $this->stub('aggregate.resource', $this->replacements()));
+        }
     }
 
     /**

--- a/stubs/aggregate.api-controller.stub
+++ b/stubs/aggregate.api-controller.stub
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\{{ context }}\{{ plural }}\Infrastructure\Http\Controllers\API;
 
 use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
-use Illuminate\Http\JsonResponse;
+use App\{{ context }}\{{ plural }}\Infrastructure\Http\Resources\{{ aggregate }}Resource;
 
 /**
  * Class {{ aggregate }}Controller
@@ -17,10 +17,13 @@ class {{ aggregate }}Controller
 {
     public function __construct(private readonly {{ aggregate }}Repository $repository) {}
 
-    public function show(string $id): JsonResponse
+    public function show(string $id): {{ aggregate }}Resource
     {
+        // Through the resource rather than the model: returning the aggregate
+        // itself publishes every attribute it happens to hold.
+        //
         // abort() rather than the domain's NotFound: an unhandled domain
         // exception would answer 500 to an ordinary missing record.
-        return new JsonResponse($this->repository->find($id) ?? abort(404));
+        return new {{ aggregate }}Resource($this->repository->find($id) ?? abort(404));
     }
 }

--- a/stubs/aggregate.resource.stub
+++ b/stubs/aggregate.resource.stub
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\{{ context }}\{{ plural }}\Infrastructure\Http\Resources;
+
+use App\{{ context }}\{{ plural }}\Domain\{{ aggregate }};
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Class {{ aggregate }}Resource
+ *
+ * One definition of what a {{ aggregate }} publishes, for the API and for the
+ * Inertia page alike. It starts closed: an attribute appears here because
+ * somebody decided it should, not because it happens to be on the model.
+ *
+ * The API controller returns this and Laravel wraps it in a `data` key, which
+ * is where a paginated listing would later put its `meta`. The Inertia
+ * controller passes resolve() instead, since the prop name is already the
+ * envelope there.
+ *
+ * @mixin {{ aggregate }}
+ */
+class {{ aggregate }}Resource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+        ];
+    }
+}

--- a/stubs/aggregate.web-controller.stub
+++ b/stubs/aggregate.web-controller.stub
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\{{ context }}\{{ plural }}\Infrastructure\Http\Controllers;
 
 use App\{{ context }}\{{ plural }}\Domain\Contracts\{{ aggregate }}Repository;
+use App\{{ context }}\{{ plural }}\Infrastructure\Http\Resources\{{ aggregate }}Resource;
 use App\Shared\Infrastructure\Http\Controllers\InertiaController;
 use Illuminate\Http\Request;
 use Inertia\Response;
@@ -29,8 +30,11 @@ class {{ aggregate }}Controller extends InertiaController
         // unhandled one would answer 500 to an ordinary missing record.
         ${{ variable }} = $this->repository->find($id) ?? abort(404);
 
+        // resolve() rather than the resource itself: Inertia resolves an
+        // Arrayable by calling toArray() directly, which skips the filtering
+        // and leaves a MissingValue object wherever a when() dropped a field.
         return $this->render($request, '{{ plural }}/Show', [
-            '{{ variable }}' => ${{ variable }},
+            '{{ variable }}' => (new {{ aggregate }}Resource(${{ variable }}))->resolve($request),
         ]);
     }
 }

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -123,6 +123,34 @@ test('the web flag generates an Inertia controller', function () {
 
     expect(app_path('ScaffoldFixture/Widgets/Infrastructure/Http/Controllers/API/WidgetController.php'))
         ->not->toBeFile();
+
+    // An Inertia page publishes the same way an API does, so the resource is
+    // not an --api concern.
+    expect(app_path('ScaffoldFixture/Widgets/Infrastructure/Http/Resources/WidgetResource.php'))->toBeFile();
+});
+
+test('the controllers publish through a resource, not the model', function () {
+    $this->artisan('ldd:make:aggregate', [
+        'context' => 'ScaffoldFixture', 'name' => 'Widget', '--web' => true, '--api' => true,
+    ])->assertSuccessful();
+
+    $resource = app_path('ScaffoldFixture/Widgets/Infrastructure/Http/Resources/WidgetResource.php');
+
+    // Closed to begin with: an attribute is published because somebody listed
+    // it, not because it happens to sit on the model.
+    expect(File::get($resource))
+        ->toContain('class WidgetResource extends JsonResource')
+        ->toContain("'id' => \$this->id,")
+        ->and(php_parses($resource))->toBeTrue();
+
+    expect(File::get(app_path('ScaffoldFixture/Widgets/Infrastructure/Http/Controllers/API/WidgetController.php')))
+        ->toContain('return new WidgetResource(');
+
+    // resolve() rather than the resource itself: Inertia resolves an Arrayable
+    // by calling toArray(), which skips the filtering when() depends on and
+    // leaves a MissingValue object in the props.
+    expect(File::get(app_path('ScaffoldFixture/Widgets/Infrastructure/Http/Controllers/WidgetController.php')))
+        ->toContain('(new WidgetResource($widget))->resolve($request)');
 });
 
 test('generated controllers do not ship an unbounded read', function () {


### PR DESCRIPTION
The generated API controller returned the model straight into a `JsonResponse`, so every attribute it held went over the wire, including whatever the next migration adds. The Inertia controller did the same thing to the page. Both now publish through an `{Aggregate}Resource` that starts closed, with `id` and nothing else.

The API controller returns it and Laravel wraps it in a `data` key, which is where a paginated listing would later put its `meta`. The Inertia controller passes `resolve($request)`: Inertia resolves an Arrayable by calling `toArray()` directly, so a resource handed to it whole skips the filtering `when()` relies on and leaves a `MissingValue` object in the props. Both shapes were checked against a generated aggregate.

Closes #67