### PR TITLE
feat: #76 route factories through a shared base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,10 +375,11 @@ Six things surprise people arriving from stock Laravel.
 provider, from `{Context}/Shared/Infrastructure/Http/Routes/`. `BoundedContextServiceProvider::bootRoutes()` applies
 the middleware group but *not* a URI prefix, so an `api.php` declares `Route::prefix('api')` itself.
 
-**Aggregates are identified by uuid, and built through `new()`.** A domain event carries the identifier, so the
-identifier has to exist before `save()`. `new()` assigns it up front with `HasUuids::newUniqueId()`, the same helper
-Eloquent's `creating` hook would have called later. Aggregates declare that with `BuildsFromAttributes`, which is
-what lets a factory be sure the method is there.
+**The aggregates this starter generates are identified by uuid, and built through `new()`.** A domain event carries
+the identifier, so the identifier has to exist before `save()`. `new()` assigns it up front with
+`HasUuids::newUniqueId()`, the same helper Eloquent's `creating` hook would have called later, and the aggregate
+declares that with `BuildsFromAttributes` so a factory can rely on the method being there. An aggregate adopted from
+elsewhere need not follow it: `APIToken` extends Sanctum's `PersonalAccessToken` and keeps its own key.
 
 **The aggregate root points at its own factory, and the factory lives in `Domain/Factories`.** Laravel only looks
 in `Database\Factories`, so the model declares `newFactory()`. Keeping the factory in `Domain` keeps that pointer
@@ -386,8 +387,9 @@ inside one layer, which is why `domain does not depend on infrastructure` needs 
 into `Domain` by it: the aggregate root is already an Eloquent model.
 
 Factories extend `AggregateFactory`, not Eloquent's `Factory`, so that `make()` and `create()` go through the
-aggregate's `new()`. Write one by hand against `Factory` and you get instances with no identifier and no recorded
-event, which only shows up later as rows nothing ever announced.
+aggregate's `new()`. One written against `Factory` instead would build instances with no identifier and no recorded
+event, so this is not left to whoever writes the next factory: an architecture rule fails the suite for anything in
+`Domain/Factories` that does not extend the base class.
 
 **Domain events are ComplexHeart's, not Laravel's.** They implement `ComplexHeart\Domain\Contracts\Events\Event` and
 use the `IsDomainEvent` trait, which supplies `eventId`, `eventName`, `payload` and `occurredOn`. They carry

--- a/README.md
+++ b/README.md
@@ -375,14 +375,19 @@ Six things surprise people arriving from stock Laravel.
 provider, from `{Context}/Shared/Infrastructure/Http/Routes/`. `BoundedContextServiceProvider::bootRoutes()` applies
 the middleware group but *not* a URI prefix, so an `api.php` declares `Route::prefix('api')` itself.
 
-**Aggregates are identified by uuid.** A domain event carries the identifier, so the identifier has to exist before
-`save()`. `new()` assigns it up front with `HasUuids::newUniqueId()`, the same helper Eloquent's `creating` hook would
-have called later.
+**Aggregates are identified by uuid, and built through `new()`.** A domain event carries the identifier, so the
+identifier has to exist before `save()`. `new()` assigns it up front with `HasUuids::newUniqueId()`, the same helper
+Eloquent's `creating` hook would have called later. Aggregates declare that with `BuildsFromAttributes`, which is
+what lets a factory be sure the method is there.
 
 **The aggregate root points at its own factory, and the factory lives in `Domain/Factories`.** Laravel only looks
 in `Database\Factories`, so the model declares `newFactory()`. Keeping the factory in `Domain` keeps that pointer
 inside one layer, which is why `domain does not depend on infrastructure` needs no exemption. Nothing new is let
 into `Domain` by it: the aggregate root is already an Eloquent model.
+
+Factories extend `AggregateFactory`, not Eloquent's `Factory`, so that `make()` and `create()` go through the
+aggregate's `new()`. Write one by hand against `Factory` and you get instances with no identifier and no recorded
+event, which only shows up later as rows nothing ever announced.
 
 **Domain events are ComplexHeart's, not Laravel's.** They implement `ComplexHeart\Domain\Contracts\Events\Event` and
 use the `IsDomainEvent` trait, which supplies `eventId`, `eventName`, `payload` and `occurredOn`. They carry

--- a/app/IdentityAndAccess/Users/Domain/Factories/UserFactory.php
+++ b/app/IdentityAndAccess/Users/Domain/Factories/UserFactory.php
@@ -3,14 +3,14 @@
 namespace App\IdentityAndAccess\Users\Domain\Factories;
 
 use App\IdentityAndAccess\Users\Domain\User;
-use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Shared\Domain\AggregateFactory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends Factory<User>
+ * @extends AggregateFactory<User>
  */
-class UserFactory extends Factory
+class UserFactory extends AggregateFactory
 {
     protected $model = User::class;
 
@@ -18,18 +18,6 @@ class UserFactory extends Factory
      * The current password being used by the factory.
      */
     protected static ?string $password;
-
-    /**
-     * Build the model through the aggregate's own factory method, so that
-     * seeded and tested users get an identifier and register UserCreated
-     * exactly like the ones created by the application layer.
-     *
-     * @param  array<string, mixed>  $attributes
-     */
-    public function newModel(array $attributes = []): User
-    {
-        return User::new($attributes);
-    }
 
     /**
      * Define the model's default state.

--- a/app/IdentityAndAccess/Users/Domain/User.php
+++ b/app/IdentityAndAccess/Users/Domain/User.php
@@ -7,6 +7,7 @@ use App\IdentityAndAccess\Users\Domain\Events\UserDeleted;
 use App\IdentityAndAccess\Users\Domain\Events\UserEmailUpdated;
 use App\IdentityAndAccess\Users\Domain\Events\UserNameUpdated;
 use App\IdentityAndAccess\Users\Domain\Factories\UserFactory;
+use App\Shared\Domain\BuildsFromAttributes;
 use App\Shared\Domain\HasDomainEvents;
 use App\Shared\Domain\HasProfilePhoto;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
@@ -33,8 +34,11 @@ use Laravel\Sanctum\HasApiTokens;
  * @method static UserFactory factory()
  *
  * @author Unay Santisteban <usantisteban@othercode.io>
+ *
+ * @phpstan-consistent-constructor Eloquent fixes __construct(array $attributes = []),
+ * so new static() in new() is safe for anything that extends this.
  */
-class User extends Authenticatable implements MustVerifyEmail
+class User extends Authenticatable implements BuildsFromAttributes, MustVerifyEmail
 {
     use HasApiTokens;
     use HasDomainEvents;
@@ -57,9 +61,9 @@ class User extends Authenticatable implements MustVerifyEmail
      *
      * @param  array<string, mixed>  $attributes
      */
-    public static function new(array $attributes = []): self
+    public static function new(array $attributes = []): static
     {
-        $user = new self(Arr::except($attributes, ['id']));
+        $user = new static(Arr::except($attributes, ['id']));
         $user->id = $attributes['id'] ?? $user->newUniqueId();
         $user->registerDomainEvent(UserCreated::new($user->id));
 

--- a/app/Shared/Domain/AggregateFactory.php
+++ b/app/Shared/Domain/AggregateFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class AggregateFactory
+ *
+ * Builds through the aggregate's own new() instead of Eloquent's constructor,
+ * so seeded and tested instances get an identifier and record the same domain
+ * events as the ones the application layer creates.
+ *
+ * A base class rather than a method each factory repeats: routing every
+ * aggregate needs is not something a stub should keep restating, and one
+ * factory quietly missing it produces rows no event ever announced.
+ *
+ * @template TModel of Model&BuildsFromAttributes
+ *
+ * @extends Factory<TModel>
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+abstract class AggregateFactory extends Factory
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return TModel
+     */
+    public function newModel(array $attributes = []): Model
+    {
+        return $this->modelName()::new($attributes);
+    }
+}

--- a/app/Shared/Domain/BuildsFromAttributes.php
+++ b/app/Shared/Domain/BuildsFromAttributes.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain;
+
+/**
+ * Interface BuildsFromAttributes
+ *
+ * An aggregate that is created through a named constructor rather than by
+ * `new`. That is what assigns the identifier up front, so domain events can
+ * carry it before anything is persisted.
+ *
+ * Declared so the routing in AggregateFactory is checked rather than assumed:
+ * a factory whose model has no new() is a mistake worth catching statically.
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+interface BuildsFromAttributes
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public static function new(array $attributes = []): static;
+}

--- a/app/Shared/Domain/BuildsFromAttributes.php
+++ b/app/Shared/Domain/BuildsFromAttributes.php
@@ -7,12 +7,17 @@ namespace App\Shared\Domain;
 /**
  * Interface BuildsFromAttributes
  *
- * An aggregate that is created through a named constructor rather than by
- * `new`. That is what assigns the identifier up front, so domain events can
- * carry it before anything is persisted.
+ * An aggregate that is built by calling new() on the class, rather than by
+ * constructing it directly. Going through new() is what assigns the
+ * identifier up front, so domain events can carry it before anything is
+ * persisted.
  *
  * Declared so the routing in AggregateFactory is checked rather than assumed:
  * a factory whose model has no new() is a mistake worth catching statically.
+ *
+ * The return type is static, not self, so the aggregate a subclass builds is
+ * that subclass. An implementation has to declare static too, since PHP will
+ * not let it narrow.
  *
  * @author Unay Santisteban <usantisteban@othercode.io>
  */

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Console\Commands;
 
+use App\Shared\Domain\BuildsFromAttributes;
 use App\Shared\Infrastructure\Console\Support\SourceFile;
 use Illuminate\Support\Str;
 
@@ -43,7 +44,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
     /**
      * The contract an aggregate declares so a factory can call new() on it.
      */
-    private const BUILDS_FROM_ATTRIBUTES = 'App\\Shared\\Domain\\BuildsFromAttributes';
+    private const BUILDS_FROM_ATTRIBUTES = BuildsFromAttributes::class;
 
     private string $context;
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -40,6 +40,11 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
     protected $description = 'Create an aggregate inside a bounded context';
 
+    /**
+     * The contract an aggregate declares so a factory can call new() on it.
+     */
+    private const BUILDS_FROM_ATTRIBUTES = 'App\\Shared\\Domain\\BuildsFromAttributes';
+
     private string $context;
 
     private string $aggregate;
@@ -177,6 +182,16 @@ final class MakeAggregateCommand extends ScaffoldCommand
         if ($this->wants('factory') && ! $model->declaresMethod('newFactory')) {
             $lines[] = 'use HasFactory; (imported from Illuminate\Database\Eloquent\Factories)';
             $lines[] = "protected static function newFactory(): {$this->aggregate}Factory { return {$this->aggregate}Factory::new(); }";
+        }
+
+        // An aggregate written before the factory base class existed declares
+        // new(): self and implements nothing, and the factory just generated
+        // for it does not type check against AggregateFactory's template. Both
+        // halves are named because they only work together: the interface
+        // returns static, so self would not satisfy it.
+        if ($this->wants('factory') && ! $model->implementsInterface(self::BUILDS_FROM_ATTRIBUTES)) {
+            $lines[] = 'implements BuildsFromAttributes (imported from App\Shared\Domain)';
+            $lines[] = 'and change new() to return static, building with new static(...)';
         }
 
         if ($lines === []) {

--- a/stubs/aggregate.factory.stub
+++ b/stubs/aggregate.factory.stub
@@ -5,26 +5,14 @@ declare(strict_types=1);
 namespace App\{{ context }}\{{ plural }}\Domain\Factories;
 
 use App\{{ context }}\{{ plural }}\Domain\{{ aggregate }};
-use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Shared\Domain\AggregateFactory;
 
 /**
- * @extends Factory<{{ aggregate }}>
+ * @extends AggregateFactory<{{ aggregate }}>
  */
-class {{ aggregate }}Factory extends Factory
+class {{ aggregate }}Factory extends AggregateFactory
 {
     protected $model = {{ aggregate }}::class;
-
-    /**
-     * Build through the aggregate's own factory method, so seeded and tested
-     * instances get an identifier and record the same events as the ones the
-     * application layer creates.
-     *
-     * @param  array<string, mixed>  $attributes
-     */
-    public function newModel(array $attributes = []): {{ aggregate }}
-    {
-        return {{ aggregate }}::new($attributes);
-    }
 
     /**
      * @return array<string, mixed>

--- a/stubs/aggregate.model.stub
+++ b/stubs/aggregate.model.stub
@@ -2,6 +2,7 @@
 
 namespace App\{{ context }}\{{ plural }}\Domain;
 
+use App\Shared\Domain\BuildsFromAttributes;
 use App\Shared\Domain\HasDomainEvents;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
@@ -11,8 +12,11 @@ use Illuminate\Support\Arr;
  * Class {{ aggregate }}
  *
  * @property string $id
+ *
+ * @phpstan-consistent-constructor Eloquent fixes __construct(array $attributes = []),
+ * so new static() in new() is safe for anything that extends this.
  */
-class {{ aggregate }} extends Model
+class {{ aggregate }} extends Model implements BuildsFromAttributes
 {
     use HasDomainEvents;
 {{ modelTraits }}    use HasUuids;
@@ -45,9 +49,9 @@ class {{ aggregate }} extends Model
      *
      * @param  array<string, mixed>  $attributes
      */
-    public static function new(array $attributes = []): self
+    public static function new(array $attributes = []): static
     {
-        ${{ variable }} = new self(Arr::except($attributes, ['id']));
+        ${{ variable }} = new static(Arr::except($attributes, ['id']));
         ${{ variable }}->id = $attributes['id'] ?? ${{ variable }}->newUniqueId();
 {{ modelRegisterEvent }}
         return ${{ variable }};

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -73,6 +73,21 @@ arch('domain exceptions extend exception')
     ->toBeClasses()
     ->toExtend('Exception');
 
+/*
+ * AggregateFactory routes make() and create() through the aggregate's new(),
+ * which is what assigns the identifier and records the creation event. A
+ * factory written against Eloquent's Factory instead looks ordinary and
+ * produces rows nothing ever announced, so extending it is not left to
+ * whoever writes the next one.
+ *
+ * A factory is optional, and Pest throws when a pattern matches no directory.
+ */
+if ((glob($appPath.'/*/*/Domain/Factories', GLOB_ONLYDIR) ?: []) !== []) {
+    arch('aggregate factories build through the aggregate')
+        ->expect('App\*\*\Domain\Factories')
+        ->toExtend('App\Shared\Domain\AggregateFactory');
+}
+
 arch('shared domain traits are traits')
     ->expect('App\Shared\Domain')
     ->traits()

--- a/tests/Feature/IdentityAndAccess/RegistrationTest.php
+++ b/tests/Feature/IdentityAndAccess/RegistrationTest.php
@@ -2,6 +2,7 @@
 
 use App\IdentityAndAccess\Users\Domain\Events\UserCreated;
 use App\IdentityAndAccess\Users\Domain\User;
+use ComplexHeart\Domain\Contracts\Events\EventBus;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 
@@ -46,7 +47,20 @@ test('a caller may supply the user identifier', function () {
     expect(User::new(['id' => $id, 'name' => 'Test User'])->id)->toBe($id);
 });
 
-test('users built through the factory also carry an identifier', function () {
+test('users built through the factory carry an identifier and record their creation', function () {
     expect(Str::isUuid(User::factory()->make()->id))->toBeTrue()
         ->and(Str::isUuid(User::factory()->create()->id))->toBeTrue();
+
+    // The identifier alone does not prove the factory went through new():
+    // AggregateFactory routes there for the recorded event just as much, and
+    // an aggregate that skips it persists rows nothing ever announced.
+    Event::fake([UserCreated::class]);
+
+    $user = User::factory()->make();
+    $user->publishDomainEvents(app(EventBus::class));
+
+    Event::assertDispatched(
+        UserCreated::class,
+        fn (UserCreated $event): bool => $event->user === $user->id
+    );
 });

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -114,6 +114,38 @@ test('the factory is routed through the aggregate factory method', function () {
         ->toContain('protected static function newFactory(): WidgetFactory');
 });
 
+test('it says what an older aggregate needs before a factory type checks', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
+        ->assertSuccessful();
+
+    // The shape an aggregate generated before AggregateFactory existed has.
+    $model = app_path('ScaffoldFixture/Widgets/Domain/Widget.php');
+
+    File::put($model, str_replace(
+        [
+            "use App\Shared\Domain\BuildsFromAttributes;\n",
+            'class Widget extends Model implements BuildsFromAttributes',
+            'public static function new(array $attributes = []): static',
+        ],
+        [
+            '',
+            'class Widget extends Model',
+            'public static function new(array $attributes = []): self',
+        ],
+        File::get($model)
+    ));
+
+    expect(File::get($model))->not->toContain('BuildsFromAttributes');
+
+    // The generated factory binds its template to the contract, so without
+    // this the aggregate gets a factory that does not pass static analysis
+    // and nothing says which two lines are missing.
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--factory' => true])
+        ->expectsOutputToContain('implements BuildsFromAttributes')
+        ->expectsOutputToContain('new() to return static')
+        ->assertSuccessful();
+});
+
 test('the aggregate declares the contract its factory builds through', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
         ->assertSuccessful();

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -102,13 +102,27 @@ test('the factory is routed through the aggregate factory method', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--factory' => true])
         ->assertSuccessful();
 
+    // The routing lives in the base class, so the generated factory carries no
+    // newModel() of its own to forget or delete.
     expect(File::get(app_path('ScaffoldFixture/Widgets/Domain/Factories/WidgetFactory.php')))
-        ->toContain('return Widget::new($attributes);');
+        ->toContain('class WidgetFactory extends AggregateFactory')
+        ->not->toContain('newModel');
 
     // Laravel would not find a factory outside Database\Factories, so the
     // model has to point at it explicitly.
     expect(File::get(app_path('ScaffoldFixture/Widgets/Domain/Widget.php')))
         ->toContain('protected static function newFactory(): WidgetFactory');
+});
+
+test('the aggregate declares the contract its factory builds through', function () {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
+        ->assertSuccessful();
+
+    // AggregateFactory calls new() on whatever model it is given, so a model
+    // without one is a mistake worth catching before it reaches a seeder.
+    expect(File::get(app_path('ScaffoldFixture/Widgets/Domain/Widget.php')))
+        ->toContain('class Widget extends Model implements BuildsFromAttributes')
+        ->toContain('public static function new(array $attributes = []): static');
 });
 
 test('the web flag generates an Inertia controller', function () {


### PR DESCRIPTION
Generated factories each carried their own \`newModel()\`. That routing now lives in \`App\Shared\Domain\AggregateFactory\`, so a factory cannot quietly lose it and start producing rows with no identifier and no recorded event.

It is checked rather than assumed: \`BuildsFromAttributes\` declares \`new()\`, the base class binds its template to \`Model & BuildsFromAttributes\`, and a factory pointed at a model without the method fails PHPStan where it is declared.

Closes #76