### PR TITLE
fix: #79 #77 stop treating unreadable source as empty

### DIFF
--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -108,17 +108,23 @@ final class MakeAggregateCommand extends ScaffoldCommand
         // the migration may already have been applied.
         $modelExisted = $this->files->exists("{$path}/Domain/{$this->aggregate}.php");
 
-        // Unreadable is not the same as absent. Every question this command
-        // asks of an existing model answers false when it does not parse, so
-        // the table guard below would wave a mismatched migration through and
-        // the hints would advise adding what is already there. Refuse instead,
-        // the way the provider is refused when it does not parse.
+        // A file on disk is not the same as an aggregate that can be read.
+        // Every question below answers false for a file that does not parse
+        // and for one that holds no class at all, and false read off either is
+        // not a fact about the aggregate: the table guard would wave a
+        // mismatched migration through, and the hints would advise adding what
+        // is already there. So the question asked is whether the class was
+        // found, not whether the file parsed.
         $model = SourceFile::at("{$path}/Domain/{$this->aggregate}.php");
 
-        if ($modelExisted && ! $model->parsed()) {
-            $this->components->error("[{$this->aggregate}] does not parse, so nothing about it could be checked.");
+        if ($modelExisted && ! $model->declaresClass($this->aggregate)) {
+            $reason = $model->parsed()
+                ? "declares no class {$this->aggregate}"
+                : 'does not parse';
+
+            $this->components->error("[{$this->aggregate}] could not be read: {$this->relative("{$path}/Domain/{$this->aggregate}.php")} {$reason}.");
             $this->components->bulletList([
-                "Fix {$this->relative("{$path}/Domain/{$this->aggregate}.php")}, then run this again.",
+                'Fix it, then run this again.',
             ]);
 
             return self::FAILURE;

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -108,10 +108,26 @@ final class MakeAggregateCommand extends ScaffoldCommand
         // the migration may already have been applied.
         $modelExisted = $this->files->exists("{$path}/Domain/{$this->aggregate}.php");
 
+        // Unreadable is not the same as absent. Every question this command
+        // asks of an existing model answers false when it does not parse, so
+        // the table guard below would wave a mismatched migration through and
+        // the hints would advise adding what is already there. Refuse instead,
+        // the way the provider is refused when it does not parse.
+        $model = SourceFile::at("{$path}/Domain/{$this->aggregate}.php");
+
+        if ($modelExisted && ! $model->parsed()) {
+            $this->components->error("[{$this->aggregate}] does not parse, so nothing about it could be checked.");
+            $this->components->bulletList([
+                "Fix {$this->relative("{$path}/Domain/{$this->aggregate}.php")}, then run this again.",
+            ]);
+
+            return self::FAILURE;
+        }
+
         // The model is never rewritten, so a migration for a table it does not
         // declare creates one nothing reads, next to the one it does use.
         if ($this->wants('migration') && $modelExisted) {
-            $declared = $this->tableDeclaredIn("{$path}/Domain/{$this->aggregate}.php");
+            $declared = $model->propertyString('table');
 
             if ($declared !== null && $declared !== $this->table) {
                 $this->components->error("[{$this->aggregate}] declares table [{$declared}], not [{$this->table}].");
@@ -147,7 +163,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $this->newLine();
         $this->components->info("Aggregate [{$this->aggregate}] ".($modelExisted ? 'updated' : 'created')." in [{$this->context}].");
 
-        $this->printModelHints($path, $modelExisted);
+        $this->printModelHints($model, $modelExisted);
         $this->printEventHints($path);
         $this->printSeederHints();
         $this->printRouteHints();
@@ -164,7 +180,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
      * rewritten once it exists. Adding either option later costs a line or
      * two by hand, which is the price of never losing what the model grew.
      */
-    private function printModelHints(string $path, bool $modelExisted): void
+    private function printModelHints(SourceFile $model, bool $modelExisted): void
     {
         if (! $modelExisted) {
             return;
@@ -172,8 +188,9 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
         // What the model already carries decides this, not the flags: running
         // the same command twice would otherwise advise redeclaring
-        // newFactory(), which is fatal, and registering the event twice.
-        $model = SourceFile::at("{$path}/Domain/{$this->aggregate}.php");
+        // newFactory(), which is fatal, and registering the event twice. It is
+        // the instance handle() already read, so a model that does not parse
+        // never reaches here to be read as carrying nothing.
         $lines = [];
 
         if ($this->wants('events') && ! $model->calls('registerDomainEvent')) {
@@ -223,12 +240,35 @@ final class MakeAggregateCommand extends ScaffoldCommand
         // What the aggregate's application layer already does decides this.
         $application = "{$path}/Application";
 
+        $unreadable = [];
+
         if ($this->files->isDirectory($application)) {
             foreach ($this->files->allFiles($application) as $file) {
-                if (SourceFile::at($file->getPathname())->calls('publishDomainEvents')) {
+                $source = SourceFile::at($file->getPathname());
+
+                if (! $source->parsed()) {
+                    $unreadable[] = $this->relative($file->getPathname());
+
+                    continue;
+                }
+
+                if ($source->calls('publishDomainEvents')) {
                     return;
                 }
             }
+        }
+
+        // One of them may well be the use case that publishes, so the advice
+        // below would be telling somebody to write what they already have.
+        if ($unreadable !== []) {
+            $this->newLine();
+            $this->line('  <fg=yellow>Could not tell whether anything publishes '."{$this->aggregate}Created".': these do not parse:</>');
+
+            foreach ($unreadable as $file) {
+                $this->line("  <fg=gray>{$file}</>");
+            }
+
+            return;
         }
 
         $this->newLine();
@@ -254,13 +294,23 @@ final class MakeAggregateCommand extends ScaffoldCommand
         $file = app_path('Shared/Infrastructure/Persistence/Seeders/DatabaseSeeder.php');
         $class = "App\\{$this->context}\\{$this->plural}\\Infrastructure\\Persistence\\Seeders\\{$this->aggregate}Seeder";
 
+        $seeder = SourceFile::at($file);
+
         // What DatabaseSeeder already lists decides this, not the flag, so
         // re-running to add another option does not advise a second entry.
-        if (SourceFile::at($file)->references($class)) {
+        if ($seeder->references($class)) {
             return;
         }
 
         $this->newLine();
+
+        // It may already list the entry, so say what is wrong rather than
+        // advise adding a duplicate to a file that has to be fixed first.
+        if ($this->files->exists($file) && ! $seeder->parsed()) {
+            $this->line("  <fg=yellow>{$this->relative($file)} does not parse, so whether it lists {$this->aggregate}Seeder could not be checked.</>");
+
+            return;
+        }
 
         if (! $this->files->exists($file)) {
             $this->line("  <fg=yellow>{$this->aggregate}Seeder will not run: no DatabaseSeeder at {$this->relative($file)}.</>");
@@ -324,11 +374,22 @@ final class MakeAggregateCommand extends ScaffoldCommand
             //
             // Asked by its full name, which is what tells the web controller
             // from the one under API: they share a short name.
-            if (SourceFile::at($file)->references($snippet['controller'])) {
+            $routes = SourceFile::at($file);
+
+            if ($routes->references($snippet['controller'])) {
                 continue;
             }
 
             $this->newLine();
+
+            // It may already declare the route, so pasting the canonical one
+            // back would replace whatever middleware it was wrapped in.
+            if ($this->files->exists($file) && ! $routes->parsed()) {
+                $this->line("  <fg=yellow>{$this->relative($file)} does not parse, so whether it declares the {$kind} route could not be checked.</>");
+
+                continue;
+            }
+
             $this->line("  Add to <options=bold>{$this->relative($file)}</>:");
 
             foreach ($snippet['lines'] as $line) {
@@ -350,11 +411,6 @@ final class MakeAggregateCommand extends ScaffoldCommand
             $this->newLine();
             $this->line("  Create the page at <options=bold>{$this->relative($page)}</>");
         }
-    }
-
-    private function tableDeclaredIn(string $model): ?string
-    {
-        return SourceFile::at($model)->propertyString('table');
     }
 
     /**

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -243,34 +243,22 @@ final class MakeAggregateCommand extends ScaffoldCommand
             return;
         }
 
-        // What the aggregate's application layer already does decides this.
-        $application = "{$path}/Application";
+        // What the aggregate's application layer already does decides this,
+        // asked through the shared helper so this command and ldd:make:use-case
+        // cannot answer it differently.
+        $answer = $this->publishesDomainEvents("{$path}/Application");
 
-        $unreadable = [];
-
-        if ($this->files->isDirectory($application)) {
-            foreach ($this->files->allFiles($application) as $file) {
-                $source = SourceFile::at($file->getPathname());
-
-                if (! $source->parsed()) {
-                    $unreadable[] = $this->relative($file->getPathname());
-
-                    continue;
-                }
-
-                if ($source->calls('publishDomainEvents')) {
-                    return;
-                }
-            }
+        if ($answer['publishes']) {
+            return;
         }
 
         // One of them may well be the use case that publishes, so the advice
         // below would be telling somebody to write what they already have.
-        if ($unreadable !== []) {
+        if ($answer['unreadable'] !== []) {
             $this->newLine();
-            $this->line('  <fg=yellow>Could not tell whether anything publishes '."{$this->aggregate}Created".': these do not parse:</>');
+            $this->line("  <fg=yellow>Could not tell whether anything publishes {$this->aggregate}Created: these do not parse:</>");
 
-            foreach ($unreadable as $file) {
+            foreach ($answer['unreadable'] as $file) {
                 $this->line("  <fg=gray>{$file}</>");
             }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
@@ -128,7 +128,7 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
         $handler = SourceFile::at($file);
 
         // Asked before concluding anything from what the file does not hold. A
-        // file that does not parse, and one holding no {$name} at all, both say
+        // file that does not parse, and one holding no such class at all, both say
         // "implements nothing", and telling somebody to add an interface to a
         // class that is not there names the wrong problem.
         if (! $handler->declaresClass($name)) {

--- a/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
@@ -125,7 +125,19 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
      */
     private function printQueuedHint(string $file, string $name): void
     {
-        if (SourceFile::at($file)->implementsInterface('Illuminate\\Contracts\\Queue\\ShouldQueue')) {
+        $handler = SourceFile::at($file);
+
+        // Asked before concluding anything from what the file does not hold. A
+        // file that does not parse, and one holding no {$name} at all, both say
+        // "implements nothing", and telling somebody to add an interface to a
+        // class that is not there names the wrong problem.
+        if (! $handler->declaresClass($name)) {
+            $this->components->warn("{$name} already existed but could not be read from {$this->relative($file)}, so whether it is queued is unknown.");
+
+            return;
+        }
+
+        if ($handler->implementsInterface('Illuminate\\Contracts\\Queue\\ShouldQueue')) {
             return;
         }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Console\Commands;
 
-use App\Shared\Infrastructure\Console\Support\SourceFile;
 use Illuminate\Support\Str;
 
 /**
@@ -79,18 +78,28 @@ final class MakeUseCaseCommand extends ScaffoldCommand
 
         // And only until something publishes them. This is the same question
         // ldd:make:aggregate asks before printing its own version, and the two
-        // have no business disagreeing about the answer.
-        $application = "{$target['path']}/Application";
+        // have no business disagreeing about the answer, so both ask it through
+        // the one helper rather than each keeping a copy that can drift.
+        $answer = $this->publishesDomainEvents("{$target['path']}/Application");
 
-        if ($this->files->isDirectory($application)) {
-            foreach ($this->files->allFiles($application) as $file) {
-                if (SourceFile::at($file->getPathname())->calls('publishDomainEvents')) {
-                    return;
-                }
-            }
+        if ($answer['publishes']) {
+            return;
         }
 
         $this->newLine();
+
+        // Any of them may be the use case that publishes, so advising one
+        // would be asking for what is already written.
+        if ($answer['unreadable'] !== []) {
+            $this->line("  <fg=yellow>Could not tell whether anything publishes {$target['aggregate']}'s events: these do not parse:</>");
+
+            foreach ($answer['unreadable'] as $file) {
+                $this->line("  <fg=gray>{$file}</>");
+            }
+
+            return;
+        }
+
         $this->line("  <fg=yellow>{$target['aggregate']} records domain events. A use case that creates or changes one</>");
         $this->line('  <fg=yellow>should publish them, which is what --publishes scaffolds.</>');
     }

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Console\Commands;
 
+use App\Shared\Infrastructure\Console\Support\SourceFile;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
@@ -162,6 +163,47 @@ abstract class ScaffoldCommand extends Command
     protected function relative(string $path): string
     {
         return Str::after($path, base_path().DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * Whether anything in an aggregate's application layer publishes its
+     * recorded domain events.
+     *
+     * Two commands ask this before advising a use case that publishes, and
+     * they have no business disagreeing about the answer. They did, once: one
+     * learned to skip a file it could not read and the other went on treating
+     * unreadable as "does not publish", which is how you get told to write a
+     * use case that is sitting in the file nobody could parse. One
+     * implementation is the only thing that keeps the two honest.
+     *
+     * Files that do not parse are returned rather than counted either way,
+     * since any of them may be the use case that publishes.
+     *
+     * @return array{publishes: bool, unreadable: list<string>}
+     */
+    protected function publishesDomainEvents(string $applicationPath): array
+    {
+        $unreadable = [];
+
+        if (! $this->files->isDirectory($applicationPath)) {
+            return ['publishes' => false, 'unreadable' => []];
+        }
+
+        foreach ($this->files->allFiles($applicationPath) as $file) {
+            $source = SourceFile::at($file->getPathname());
+
+            if (! $source->parsed()) {
+                $unreadable[] = $this->relative($file->getPathname());
+
+                continue;
+            }
+
+            if ($source->calls('publishDomainEvents')) {
+                return ['publishes' => true, 'unreadable' => []];
+            }
+        }
+
+        return ['publishes' => false, 'unreadable' => $unreadable];
     }
 
     /**

--- a/app/Shared/Infrastructure/Console/Support/SourceFile.php
+++ b/app/Shared/Infrastructure/Console/Support/SourceFile.php
@@ -102,6 +102,24 @@ final class SourceFile
     }
 
     /**
+     * Whether the file declares a class by this short name.
+     *
+     * Asked before anything is concluded from what a file does not contain.
+     * A file that fails to parse and one that holds nothing both answer no to
+     * every other question here, and "no such method" read off either of them
+     * is not a fact about the class, it is the absence of the class.
+     */
+    public function declaresClass(string $name): bool
+    {
+        return $this->finder->findFirst(
+            $this->ast,
+            fn (Node $node): bool => $node instanceof Node\Stmt\Class_
+                && $node->name !== null
+                && $node->name->toString() === $name
+        ) !== null;
+    }
+
+    /**
      * Whether a class in the file declares this method.
      */
     public function declaresMethod(string $method): bool

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -166,6 +166,24 @@ arch('shared context does not depend on any bounded context')
     ->not->toUse(array_map(fn (string $c): string => 'App\\'.$c, $boundedContexts));
 
 /*
+ * One file under app/Shared is exempt from the rule above, and not by anyone's
+ * decision: DatabaseSeeder declares the Database\Seeders namespace, which
+ * composer.json maps into Shared so that `db:seed` resolves it with no
+ * --class. The rule matches on namespace, so it never sees the file, and the
+ * file does reach into every context on purpose, the way
+ * bootstrap/providers.php does.
+ *
+ * The exemption is fine. Its being silent is not: any second file added there
+ * would inherit it without anyone noticing. So the exception is pinned to the
+ * one file that earns it, and a new one has to be argued for here first.
+ */
+test('the seeders directory in Shared holds only the root seeder', function () use ($appPath) {
+    $files = array_map('basename', glob($appPath.'/Shared/Infrastructure/Persistence/Seeders/*.php') ?: []);
+
+    expect($files)->toBe(['DatabaseSeeder.php']);
+});
+
+/*
 |--------------------------------------------------------------------------
 | Service Providers
 |--------------------------------------------------------------------------

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -407,6 +407,20 @@ test('it stays quiet when the application layer already publishes', function () 
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
         ->doesntExpectOutputToContain('Nothing publishes WidgetCreated.')
         ->assertSuccessful();
+
+    // One it cannot read may be the use case that publishes, and both commands
+    // ask this through one helper so they cannot answer it differently.
+    File::put("{$application}/CreateWidget.php", "<?php\n\nclass CreateWidget {\n");
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
+        ->expectsOutputToContain('Could not tell whether anything publishes')
+        ->doesntExpectOutputToContain('Nothing publishes WidgetCreated.')
+        ->assertSuccessful();
+
+    $this->artisan('ldd:make:use-case', ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'UpdateWidget'])
+        ->expectsOutputToContain('Could not tell whether anything publishes')
+        ->doesntExpectOutputToContain('records domain events')
+        ->assertSuccessful();
 });
 
 test('it does not re-advise a route the file already declares', function () {

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -470,6 +470,43 @@ test('it refuses a migration for a table the model does not declare', function (
         ->toHaveCount(1);
 });
 
+/*
+ * Every question this command asks of an existing model answers false when it
+ * does not parse, so unreadable would otherwise read as "declares no table",
+ * which is exactly what the guard above takes as permission to proceed.
+ */
+test('it refuses to reason about a model that does not parse', function () {
+    $args = ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true];
+
+    $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
+
+    File::put(app_path('ScaffoldFixture/Widgets/Domain/Widget.php'), "<?php\n\nclass Widget extends Model {\n");
+
+    $this->artisan('ldd:make:aggregate', $args + ['--table' => 'renamed'])
+        ->expectsOutputToContain('does not parse')
+        ->assertFailed();
+
+    // The mismatched migration the unreadable model would have waved through.
+    expect(File::glob(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/Migrations/*.php')))
+        ->toHaveCount(1);
+});
+
+test('it says a DatabaseSeeder it cannot read is unread, rather than advising a duplicate', function () {
+    $seeder = app_path('Shared/Infrastructure/Persistence/Seeders/DatabaseSeeder.php');
+    $backup = File::get($seeder);
+
+    File::put($seeder, "<?php\n\nnamespace Database\Seeders;\n\nclass DatabaseSeeder {\n");
+
+    try {
+        $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--seeder' => true])
+            ->expectsOutputToContain('does not parse')
+            ->doesntExpectOutputToContain('WidgetSeeder::class,')
+            ->assertSuccessful();
+    } finally {
+        File::put($seeder, $backup);
+    }
+});
+
 test('re-running adds the missing piece without touching the model', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertSuccessful();
 

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -475,21 +475,29 @@ test('it refuses a migration for a table the model does not declare', function (
  * does not parse, so unreadable would otherwise read as "declares no table",
  * which is exactly what the guard above takes as permission to proceed.
  */
-test('it refuses to reason about a model that does not parse', function () {
+test('it refuses to reason about a model it cannot read', function (string $contents, string $reason) {
     $args = ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--migration' => true];
 
     $this->artisan('ldd:make:aggregate', $args)->assertSuccessful();
 
-    File::put(app_path('ScaffoldFixture/Widgets/Domain/Widget.php'), "<?php\n\nclass Widget extends Model {\n");
+    File::put(app_path('ScaffoldFixture/Widgets/Domain/Widget.php'), $contents);
 
     $this->artisan('ldd:make:aggregate', $args + ['--table' => 'renamed'])
-        ->expectsOutputToContain('does not parse')
+        ->expectsOutputToContain($reason)
         ->assertFailed();
 
-    // The mismatched migration the unreadable model would have waved through.
+    // The mismatched migration an unread model would have waved through: a
+    // second create table for an aggregate that already has one.
     expect(File::glob(app_path('ScaffoldFixture/Widgets/Infrastructure/Persistence/Migrations/*.php')))
         ->toHaveCount(1);
-});
+})->with([
+    // Answers false to every question because it never parsed.
+    'unparseable' => ["<?php\n\nclass Widget extends Model {\n", 'does not parse'],
+    // Parses perfectly well, and holds no aggregate to answer for.
+    'empty' => ["<?php\n", 'declares no class Widget'],
+    // Parses, holds a class, but not the one being reasoned about.
+    'another class' => ["<?php\n\nclass Gadget {}\n", 'declares no class Widget'],
+]);
 
 test('it says a DatabaseSeeder it cannot read is unread, rather than advising a duplicate', function () {
     $seeder = app_path('Shared/Infrastructure/Persistence/Seeders/DatabaseSeeder.php');

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -138,6 +138,23 @@ test('queued leaves a handler it did not write alone', function () {
 
     expect(File::get(app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php')))
         ->not->toContain('ShouldQueue');
+
+    // A handler holding no such class says "implements nothing" just as loudly
+    // as one that is simply not queued, and the advice for the two differs.
+    File::put(app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php'), "<?php\n");
+
+    // The run above wired the event back, and a second handler for one already
+    // mapped is refused before the hint is ever reached.
+    File::put($this->provider, str_replace(
+        '        WidgetCreated::class => NotifyAccounting::class,'."\n",
+        '',
+        File::get($this->provider)
+    ));
+
+    $this->artisan('ldd:make:event-handler', $args + ['--queued' => true])
+        ->expectsOutputToContain('could not be read')
+        ->doesntExpectOutputToContain('Add `implements ShouldQueue` to it by hand')
+        ->assertSuccessful();
 });
 
 test('it does not claim to have created a handler it skipped', function () {

--- a/tests/Unit/Shared/SourceFileTest.php
+++ b/tests/Unit/Shared/SourceFileTest.php
@@ -156,6 +156,18 @@ test('it says whether it could read the file at all', function () {
         ->and(SourceFile::at('/no/such/file.php')->parsed())->toBeTrue();
 });
 
+test('it tells a declared class from a file that merely parses', function () {
+    $declared = SourceFile::of('<?php class Widget {}');
+
+    expect($declared->declaresClass('Widget'))->toBeTrue()
+        // Parses, holds a class, just not the one being asked about.
+        ->and($declared->declaresClass('Gadget'))->toBeFalse()
+        // Parses and holds nothing, which is not the same as holding a Widget
+        // that happens to declare nothing.
+        ->and(SourceFile::of('<?php')->declaresClass('Widget'))->toBeFalse()
+        ->and(SourceFile::of('<?php class Widget {')->declaresClass('Widget'))->toBeFalse();
+});
+
 test('a file that does not parse answers no to everything', function () {
     $source = SourceFile::of('<?php class Broken {');
 


### PR DESCRIPTION
Five of the six `SourceFile` readers took "does not parse" as "contains nothing". The model was the one with consequences: `tableDeclaredIn()` returned null, null meant "declares no table", and that let a mismatched migration through. The command now refuses when an existing model does not parse. The other three only printed advice, and now say the file could not be read instead.

`DatabaseSeeder` escapes the `App\Shared` isolation rule because it declares the `Database\Seeders` namespace and Pest matches on namespace. The exemption is right, but it covered the directory rather than the file, so it is now pinned to the one file that earns it.

Closes #79
Closes #77