### PR TITLE
fix: #81 flash banners and alerts outside the history state

### DIFF
--- a/app/Shared/Infrastructure/Http/Banner.php
+++ b/app/Shared/Infrastructure/Http/Banner.php
@@ -19,10 +19,10 @@ namespace App\Shared\Infrastructure\Http;
 final class Banner
 {
     /**
-     * Flashed at `flash.banner`, never as a whole `flash` array: the session
-     * expands the dots into the same place, and it leaves room beside it for
-     * an alert flashed by the same redirect. Writing `flash` entire replaces
-     * whatever was there, so the two would silently take turns.
+     * Flashed through Inertia rather than shared as a prop, so it reaches the
+     * page once and is gone: shared props are written into the history entry
+     * and merged back on a partial reload, and a banner that outlives its
+     * redirect reappears on the Back button.
      *
      * @return array{message: string, style: string}
      */

--- a/app/Shared/Infrastructure/Http/Banner.php
+++ b/app/Shared/Infrastructure/Http/Banner.php
@@ -19,11 +19,6 @@ namespace App\Shared\Infrastructure\Http;
 final class Banner
 {
     /**
-     * Flashed through Inertia rather than shared as a prop, so it reaches the
-     * page once and is gone: shared props are written into the history entry
-     * and merged back on a partial reload, and a banner that outlives its
-     * redirect reappears on the Back button.
-     *
      * @return array{message: string, style: string}
      */
     public static function of(string $style, string $message): array

--- a/app/Shared/Infrastructure/Http/Middleware/ShareInertiaData.php
+++ b/app/Shared/Infrastructure/Http/Middleware/ShareInertiaData.php
@@ -28,7 +28,6 @@ class ShareInertiaData
                     'canUpdatePassword' => Features::enabled(Features::updatePasswords()),
                     'canUpdateProfileInformation' => Features::canUpdateProfileInformation(),
                     'hasEmailVerification' => Features::enabled(Features::emailVerification()),
-                    'flash' => $request->session()->get('flash', []),
                     'hasAccountDeletionFeatures' => true,
                     'hasTermsAndPrivacyPolicyFeature' => true,
                     'managesProfilePhotos' => true,

--- a/app/Shared/Infrastructure/Http/Middleware/ShareInertiaData.php
+++ b/app/Shared/Infrastructure/Http/Middleware/ShareInertiaData.php
@@ -20,9 +20,7 @@ class ShareInertiaData
     public function handle($request, $next)
     {
         Inertia::share([
-            'context' => function () use ($request) {
-                $user = $request->user();
-
+            'context' => function () {
                 return [
                     'canManageTwoFactorAuthentication' => Features::canManageTwoFactorAuthentication(),
                     'canUpdatePassword' => Features::enabled(Features::updatePasswords()),

--- a/app/Shared/SharedServiceProvider.php
+++ b/app/Shared/SharedServiceProvider.php
@@ -72,12 +72,12 @@ class SharedServiceProvider extends BoundedContextServiceProvider
         // caller types is ours; the token is whatever the reader answers to.
         //
         // Inertia::flash rather than ->with(): a shared prop is written into
-        // the browser's history state and merged back on a partial reload, so
+        // the browser's history entry and merged back on a partial reload, so
         // a banner reappears on the Back button and a dialog re-opens on a
-        // page that never flashed it. Flash data is stripped from the history
-        // entry and dropped on the next response, which is what one-time
-        // means. It also spreads over whatever is already flashed, so a
-        // banner and an alert can ride the same redirect.
+        // page that never flashed it. Flash data is kept out of that entry and
+        // is pulled by the first response that renders a page, which is what
+        // one-time means. It also spreads over whatever is already flashed, so
+        // a banner and an alert can ride the same redirect.
 
         RedirectResponse::macro('withSuccessBanner', function (string $message) {
             /** @var RedirectResponse $this */

--- a/app/Shared/SharedServiceProvider.php
+++ b/app/Shared/SharedServiceProvider.php
@@ -75,8 +75,8 @@ class SharedServiceProvider extends BoundedContextServiceProvider
         // the browser's history entry and merged back on a partial reload, so
         // a banner reappears on the Back button and a dialog re-opens on a
         // page that never flashed it. Flash data is kept out of that entry and
-        // is pulled by the first response that renders a page, which is what
-        // one-time means. It also spreads over whatever is already flashed, so
+        // is pulled by the first Inertia response that renders a page, which
+        // is what one-time means. It also spreads over whatever is already flashed, so
         // a banner and an alert can ride the same redirect.
 
         RedirectResponse::macro('withSuccessBanner', function (string $message) {

--- a/app/Shared/SharedServiceProvider.php
+++ b/app/Shared/SharedServiceProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Vite;
+use Inertia\Inertia;
 use Laravel\Fortify\Events\PasswordUpdatedViaController;
 
 /**
@@ -70,47 +71,68 @@ class SharedServiceProvider extends BoundedContextServiceProvider
         // whose icons are named success, error, warning and info. The name a
         // caller types is ours; the token is whatever the reader answers to.
         //
-        // Both flash through a dotted key so a redirect can carry a banner and
-        // an alert at once: flashing `flash` whole replaces it, and one of the
-        // two would quietly go missing.
+        // Inertia::flash rather than ->with(): a shared prop is written into
+        // the browser's history state and merged back on a partial reload, so
+        // a banner reappears on the Back button and a dialog re-opens on a
+        // page that never flashed it. Flash data is stripped from the history
+        // entry and dropped on the next response, which is what one-time
+        // means. It also spreads over whatever is already flashed, so a
+        // banner and an alert can ride the same redirect.
+
         RedirectResponse::macro('withSuccessBanner', function (string $message) {
             /** @var RedirectResponse $this */
-            return $this->with('flash.banner', Banner::of('success', $message));
+            Inertia::flash('banner', Banner::of('success', $message));
+
+            return $this;
         });
 
         RedirectResponse::macro('withInfoBanner', function (string $message) {
             /** @var RedirectResponse $this */
-            return $this->with('flash.banner', Banner::of('info', $message));
+            Inertia::flash('banner', Banner::of('info', $message));
+
+            return $this;
         });
 
         RedirectResponse::macro('withWarningBanner', function (string $message) {
             /** @var RedirectResponse $this */
-            return $this->with('flash.banner', Banner::of('warning', $message));
+            Inertia::flash('banner', Banner::of('warning', $message));
+
+            return $this;
         });
 
         RedirectResponse::macro('withErrorBanner', function (string $message) {
             /** @var RedirectResponse $this */
-            return $this->with('flash.banner', Banner::of('danger', $message));
+            Inertia::flash('banner', Banner::of('danger', $message));
+
+            return $this;
         });
 
         RedirectResponse::macro('withSuccessAlert', function (string $message, string $title = '') {
             /** @var RedirectResponse $this */
-            return $this->with('flash.alert', Alert::of('success', $message, $title));
+            Inertia::flash('alert', Alert::of('success', $message, $title));
+
+            return $this;
         });
 
         RedirectResponse::macro('withInfoAlert', function (string $message, string $title = '') {
             /** @var RedirectResponse $this */
-            return $this->with('flash.alert', Alert::of('info', $message, $title));
+            Inertia::flash('alert', Alert::of('info', $message, $title));
+
+            return $this;
         });
 
         RedirectResponse::macro('withWarningAlert', function (string $message, string $title = '') {
             /** @var RedirectResponse $this */
-            return $this->with('flash.alert', Alert::of('warning', $message, $title));
+            Inertia::flash('alert', Alert::of('warning', $message, $title));
+
+            return $this;
         });
 
         RedirectResponse::macro('withErrorAlert', function (string $message, string $title = '') {
             /** @var RedirectResponse $this */
-            return $this->with('flash.alert', Alert::of('error', $message, $title));
+            Inertia::flash('alert', Alert::of('error', $message, $title));
+
+            return $this;
         });
     }
 }

--- a/resources/templates/tailwindcss/js/Components/Alert.vue
+++ b/resources/templates/tailwindcss/js/Components/Alert.vue
@@ -65,7 +65,7 @@ const showErrors = (errors) => {
 };
 
 watchEffect(() => {
-    const alert = page.props.context?.flash?.alert;
+    const alert = page.flash?.alert;
 
     // Only one dialog can be open: firing a second destroys the first. A
     // message somebody wrote by hand outranks one assembled from field names,

--- a/resources/templates/tailwindcss/js/Components/Banner.vue
+++ b/resources/templates/tailwindcss/js/Components/Banner.vue
@@ -8,8 +8,8 @@ const style = ref('success');
 const message = ref('');
 
 watchEffect(async () => {
-    style.value = page.props.context.flash?.banner?.style || 'success';
-    message.value = page.props.context.flash?.banner?.message || '';
+    style.value = page.flash?.banner?.style || 'success';
+    message.value = page.flash?.banner?.message || '';
     show.value = true;
 });
 

--- a/tests/Feature/Shared/FlashTest.php
+++ b/tests/Feature/Shared/FlashTest.php
@@ -13,11 +13,11 @@ use Illuminate\Support\Facades\Route;
  * first pins the payload, the second is the one that reads both sides.
  */
 test('every banner macro flashes what the component reads', function (string $macro, string $style) {
-    Route::middleware('web')->get('/_banner', fn () => redirect('/')->{$macro}('Invoice paid.'));
+    Route::middleware('web')->get('/_banner', fn () => redirect('/login')->{$macro}('Invoice paid.'));
 
-    $this->get('/_banner')->assertSessionHas('flash', [
-        'banner' => ['message' => 'Invoice paid.', 'style' => $style],
-    ]);
+    $this->followingRedirects()->get('/_banner')->assertInertia(
+        fn ($page) => $page->hasFlash('banner', ['message' => 'Invoice paid.', 'style' => $style])
+    );
 })->with([
     'success' => ['withSuccessBanner', 'success'],
     'info' => ['withInfoBanner', 'info'],
@@ -26,13 +26,13 @@ test('every banner macro flashes what the component reads', function (string $ma
 ]);
 
 test('every alert macro flashes the agreed shape', function (string $macro, string $style) {
-    Route::middleware('web')->get('/_alert', fn () => redirect('/')->{$macro}('Card declined.', 'Payment failed'));
+    Route::middleware('web')->get('/_alert', fn () => redirect('/login')->{$macro}('Card declined.', 'Payment failed'));
 
-    $this->get('/_alert')->assertSessionHas('flash.alert', [
+    $this->followingRedirects()->get('/_alert')->assertInertia(fn ($page) => $page->hasFlash('alert', [
         'message' => 'Card declined.',
         'title' => 'Payment failed',
         'style' => $style,
-    ]);
+    ]));
 })->with([
     'success' => ['withSuccessAlert', 'success'],
     'info' => ['withInfoAlert', 'info'],
@@ -43,26 +43,27 @@ test('every alert macro flashes the agreed shape', function (string $macro, stri
 test('an alert without a title carries an empty one rather than none', function () {
     // One shape whether or not a caller supplies a title, so the front end
     // reads a string every time instead of guarding for a missing key.
-    Route::middleware('web')->get('/_untitled', fn () => redirect('/')->withInfoAlert('Saved.'));
+    Route::middleware('web')->get('/_untitled', fn () => redirect('/login')->withInfoAlert('Saved.'));
 
-    $this->get('/_untitled')->assertSessionHas('flash.alert', [
+    $this->followingRedirects()->get('/_untitled')->assertInertia(fn ($page) => $page->hasFlash('alert', [
         'message' => 'Saved.',
         'title' => '',
         'style' => 'info',
-    ]);
+    ]));
 });
 
 /*
- * Both live under `flash`, so how they are written decides whether they can
- * travel together. Flashing the whole `flash` key replaces it, which loses
- * whichever was set first and does so only in one of the two orders.
+ * Both are flashed into one array, so how they are written decides whether they
+ * can travel together: each macro has to spread over what is already there
+ * rather than replace it, or the first of the two goes missing, and only in
+ * one of the two orders.
  */
 test('a banner and an alert survive the same redirect, either order first', function (string $first, string $second) {
-    Route::middleware('web')->get('/_both', fn () => redirect('/')->{$first}('First.')->{$second}('Second.'));
+    Route::middleware('web')->get('/_both', fn () => redirect('/login')->{$first}('First.')->{$second}('Second.'));
 
-    $this->get('/_both')
-        ->assertSessionHas('flash.banner')
-        ->assertSessionHas('flash.alert');
+    $this->followingRedirects()->get('/_both')->assertInertia(
+        fn ($page) => $page->hasFlash('banner')->hasFlash('alert')
+    );
 })->with([
     'banner first' => ['withInfoBanner', 'withSuccessAlert'],
     'alert first' => ['withSuccessAlert', 'withInfoBanner'],
@@ -139,5 +140,27 @@ test('an explicit alert is not destroyed by the validation dialog', function () 
 test('the shared props are published under context', function () {
     // Renamed from `jetstream`: the package is not a dependency, and every
     // component that reads a feature flag reads it from here.
-    $this->get('/login')->assertInertia(fn ($page) => $page->has('context.flash'));
+    $this->get('/login')->assertInertia(fn ($page) => $page->has('context.canUpdatePassword'));
+});
+
+/*
+ * The point of flashing through Inertia rather than sharing a prop. A shared
+ * prop is written into the browser's history entry and merged back on a
+ * partial reload of the same component, so the banner returns on Back and the
+ * dialog re-opens on a page that never flashed it, once per router.reload().
+ *
+ * Neither half is visible from PHP, so what is pinned here is the arrangement
+ * that rules them out: the payload is never a prop, and it is spent by the
+ * response that carried it.
+ */
+test('the flash payload is not a prop, and does not outlive the response carrying it', function () {
+    Route::middleware('web')->get('/_once', fn () => redirect('/login')->withSuccessBanner('Invoice paid.')->withInfoAlert('Saved.'));
+
+    $this->followingRedirects()->get('/_once')->assertInertia(
+        fn ($page) => $page->hasFlash('banner')->missing('context.flash')
+    );
+
+    $this->get('/login')->assertInertia(
+        fn ($page) => $page->missingFlash('banner')->missingFlash('alert')
+    );
 });

--- a/tests/Feature/Shared/FlashTest.php
+++ b/tests/Feature/Shared/FlashTest.php
@@ -74,10 +74,12 @@ test('the component reads the keys the macros write, and styles every one', func
 
     // Named here because no test can render the component: the two sides have
     // to agree on these two keys and there is nothing else to notice if they
-    // stop agreeing.
+    // stop agreeing. `page.flash`, not `page.props`: the payload no longer
+    // travels as a prop, and reading it from there compiles, renders nothing
+    // and says nothing about why.
     expect($component)
-        ->toContain('flash?.banner?.style')
-        ->toContain('flash?.banner?.message');
+        ->toContain('page.flash?.banner?.style')
+        ->toContain('page.flash?.banner?.message');
 
     // A style the palette does not carry renders unstyled, which is how info
     // and warning shipped: reachable from PHP, invisible on the page, and the
@@ -96,6 +98,7 @@ test('the alert dialog is handed text, never markup, message and title alike', f
     // earlier version of this test guarded only the message, and the title
     // went out unescaped behind it.
     expect($component)
+        ->toContain('page.flash?.alert')
         ->toContain('text: alert.message')
         ->toContain('titleText: alert.title')
         ->not->toContain('${alert.message}')


### PR DESCRIPTION
Banner and alert payloads were shared props, so the browser stored them in the history entry and merged them back on a partial reload: a banner returned on Back, and a dialog re-opened on a page that never flashed it.

The eight macros now go through `Inertia::flash`, which is stripped from the history entry and spent by the response carrying it, and the shared prop is gone. Verified in Chrome that both still render, together, from `page.flash`.

Closes #81