### PR TITLE
fix: #84 stop the validation dialog replaying on Back

### DIFF
--- a/resources/templates/tailwindcss/js/Components/Alert.vue
+++ b/resources/templates/tailwindcss/js/Components/Alert.vue
@@ -12,32 +12,31 @@ const page = usePage();
 
 // The style token is SweetAlert2's own icon vocabulary, which is why the error
 // macro flashes `error` here while its banner counterpart flashes `danger`.
+//
 // Modal.vue opens a native <dialog> with showModal(), which puts it in the top
 // layer and makes everything behind it inert. A dialog mounted on the body then
 // renders underneath it, invisible and unclickable, and leaves its scroll lock
 // behind. So it is fired into whichever dialog is open, if one is.
-const dialog = (options) => Swal.fire({
-    target: document.querySelector('dialog[open]') ?? 'body',
-    buttonsStyling: true,
-    ...options,
-});
-
+//
 // `titleText` and `text`, never `title` or `html`. Both of the ones not used
 // here are parsed as markup and neither is sanitised, and a flashed alert is
 // free to carry whatever a controller interpolated into it: an account name, or
 // a filename that arrived from a form.
-const showAlert = (alert) => dialog({
+const showAlert = (alert) => Swal.fire({
+    target: document.querySelector('dialog[open]') ?? 'body',
+    buttonsStyling: true,
     icon: alert.style,
     titleText: alert.title || undefined,
     text: alert.message,
 });
 
-// Only what was flashed, never `page.props.errors`. Every form on every page
-// prints its errors in red under the field they belong to, so a dialog listing
-// them says the same thing twice, further from where it can be fixed. Worse,
-// errors are an ordinary prop: the browser keeps them in the history entry and
-// a partial reload merges them back, so the dialog reopened on the Back button
-// and on every scoped router.reload(). A flash cannot do that. It is gone once
+// Only what was flashed, never `page.props.errors`. Every form here posts
+// through useForm, whose onError fills `form.errors`, and every page renders
+// those under the field they belong to, so a dialog listing them says the same
+// thing twice and further from where it can be fixed. Worse, errors are an
+// ordinary prop: the browser keeps them in the history entry and a scoped
+// reload merges them back, so the dialog reopened on the Back button and on
+// every tick of a router.reload(). A flash cannot do that. It is gone once
 // read, which is the whole reason a one-off interruption travels as one.
 watchEffect(() => {
     const alert = page.flash?.alert;

--- a/resources/templates/tailwindcss/js/Components/Alert.vue
+++ b/resources/templates/tailwindcss/js/Components/Alert.vue
@@ -32,52 +32,18 @@ const showAlert = (alert) => dialog({
     text: alert.message,
 });
 
-/**
- * Builds the body of the validation dialog as elements rather than as markup,
- * so a message containing angle brackets stays a message.
- */
-const listOf = (errors) => {
-    const list = document.createElement('ul');
-    list.className = 'text-start';
-
-    errors.forEach(([field, message]) => {
-        const item = document.createElement('li');
-        item.textContent = `${field}: ${message}`;
-        list.append(item);
-    });
-
-    return list;
-};
-
-const showErrors = (errors) => {
-    const entries = Object.entries(errors);
-
-    // Errors keyed into a bag belong to a form, and the form prints them
-    // beside the field they came from. Interrupting with a dialog as well
-    // would say the same thing twice, further from where it can be fixed.
-    if (entries.some(([, message]) => typeof message === 'object')) {
-        return;
-    }
-
-    dialog(entries.length === 1
-        ? { icon: 'error', titleText: entries[0][0], text: entries[0][1] }
-        : { icon: 'error', titleText: 'Please check the form', html: listOf(entries) });
-};
-
+// Only what was flashed, never `page.props.errors`. Every form on every page
+// prints its errors in red under the field they belong to, so a dialog listing
+// them says the same thing twice, further from where it can be fixed. Worse,
+// errors are an ordinary prop: the browser keeps them in the history entry and
+// a partial reload merges them back, so the dialog reopened on the Back button
+// and on every scoped router.reload(). A flash cannot do that. It is gone once
+// read, which is the whole reason a one-off interruption travels as one.
 watchEffect(() => {
     const alert = page.flash?.alert;
 
-    // Only one dialog can be open: firing a second destroys the first. A
-    // message somebody wrote by hand outranks one assembled from field names,
-    // and the flash carrying it is spent either way.
     if (alert) {
         showAlert(alert);
-
-        return;
-    }
-
-    if (Object.keys(page.props.errors ?? {}).length > 0) {
-        showErrors(page.props.errors);
     }
 // Runs after the DOM settles, not before it. The default flush would fire the
 // dialog while the outgoing page is still mounted, which both measures the

--- a/tests/Feature/Shared/FlashTest.php
+++ b/tests/Feature/Shared/FlashTest.php
@@ -102,7 +102,8 @@ test('the alert dialog is handed text, never markup, message and title alike', f
         ->toContain('text: alert.message')
         ->toContain('titleText: alert.title')
         ->not->toContain('${alert.message}')
-        ->not->toContain('title: ');
+        ->not->toContain('title: ')
+        ->not->toContain('html:');
 });
 
 test('the dialog opens inside a modal that is already open', function () {
@@ -131,13 +132,22 @@ test('the alert component is mounted beside the page, not inside a layout', func
         ->not->toContain('Alert');
 });
 
-test('an explicit alert is not destroyed by the validation dialog', function () {
+test('the dialog is driven by the flash alone, never by the errors prop', function () {
     $component = File::get(base_path('resources/templates/tailwindcss/js/Components/Alert.vue'));
 
-    // Only one SweetAlert2 dialog can be open, so firing a second destroys the
-    // first. A response carrying both an alert and errors would otherwise show
-    // the field names and swallow the sentence somebody wrote.
-    expect($component)->toMatch('/if \(alert\) \{\s*showAlert\(alert\);\s*return;/');
+    // The dialog used to fire for validation errors as well. Those are an
+    // ordinary prop, so the browser kept them in the history entry and a
+    // scoped reload merged them back: it reopened on the Back button and on
+    // every tick of a router.reload(). No amount of backend work fixes that,
+    // because going Back sends no request at all.
+    //
+    // Removing it cost nothing. Every page with a form prints each error in
+    // red under the field it belongs to, so the dialog said the same thing
+    // twice, further from where it could be fixed. A controller that wants an
+    // interruption asks for one with withErrorAlert().
+    $code = preg_replace('/^\s*\/\/.*$/m', '', $component);
+
+    expect($code)->not->toContain('errors');
 });
 
 test('the shared props are published under context', function () {

--- a/tests/Feature/Shared/FlashTest.php
+++ b/tests/Feature/Shared/FlashTest.php
@@ -141,11 +141,16 @@ test('the dialog is driven by the flash alone, never by the errors prop', functi
     // every tick of a router.reload(). No amount of backend work fixes that,
     // because going Back sends no request at all.
     //
-    // Removing it cost nothing. Every page with a form prints each error in
-    // red under the field it belongs to, so the dialog said the same thing
-    // twice, further from where it could be fixed. A controller that wants an
-    // interruption asks for one with withErrorAlert().
-    $code = preg_replace('/^\s*\/\/.*$/m', '', $component);
+    // Removing it cost nothing. Every form here posts through useForm, whose
+    // onError fills form.errors, and every page renders those under the field
+    // they belong to, so the dialog said the same thing twice and further from
+    // where it could be fixed. A controller that wants an interruption asks
+    // for one with withErrorAlert().
+    //
+    // Comments are stripped first, both kinds: this is a claim about the code,
+    // and the next person to explain why errors are not read here should not
+    // have to word it around a test.
+    $code = preg_replace(['/\/\*.*?\*\//s', '/^\s*\/\/.*$/m'], '', $component);
 
     expect($code)->not->toContain('errors');
 });


### PR DESCRIPTION
The dialog also fired for `page.props.errors`, an ordinary prop: the browser keeps it in the history entry and a scoped reload merges it back, so it reopened on the Back button and on every tick of a `router.reload()`. Going Back sends no request, so no backend change could have fixed it.

Removing it costs nothing that is reachable here. Every form in the starter posts through `useForm`, whose `onError` fills `form.errors`, and all eleven pages with a form render those under the field they belong to, so the dialog said the same thing twice, further from where it could be fixed. A controller that wants to interrupt asks for it with `withErrorAlert()`, which travels as a flash and is spent on arrival.

Verified in a browser: with errors in the props no dialog opens, and a flashed alert still does.

Closes #84