### PR TITLE
fix: #86 stop the generators writing two imports of one short name

### DIFF
--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -627,7 +627,15 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
         $contract = "App\\{$this->context}\\{$this->plural}\\Domain\\Contracts\\{$this->aggregate}Repository";
         $eloquent = "App\\{$this->context}\\{$this->plural}\\Infrastructure\\Persistence\\Eloquent{$this->aggregate}Repository";
-        $binding = "        {$this->aggregate}Repository::class => Eloquent{$this->aggregate}Repository::class,";
+        // Every entry this method appends is written out in full rather than
+        // imported under its short name. Aggregate and command names are free
+        // text: two aggregates in one context may each want a SyncThings, and
+        // an aggregate called Widget puts a WidgetRepository beside whatever
+        // the provider already imports. Two imports resolving to one short
+        // name is a compile-time fatal, and because the provider is loaded
+        // from bootstrap/providers.php it takes down every request and every
+        // artisan call, including the one needed to undo it.
+        $binding = "        \\{$contract}::class => \\{$eloquent}::class,";
 
         $contents = $this->files->get($file);
 
@@ -647,9 +655,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
         }
 
         if (! in_array($contract, $declared->propertyKeys('bindings'), true)) {
-            $contents = $this->withImport($contents, $contract);
-            $contents = $contents === null ? null : $this->withImport($contents, $eloquent);
-            $contents = $contents === null ? null : $this->appendToArray($contents, 'bindings', $binding);
+            $contents = $this->appendToArray($contents, 'bindings', $binding);
         }
 
         if ($contents !== null && $this->wants('migration')) {
@@ -670,13 +676,6 @@ final class MakeAggregateCommand extends ScaffoldCommand
                 continue;
             }
 
-            // Written out in full rather than imported under its short name.
-            // A console command's name is free text, so two aggregates in one
-            // context may each have a SyncThings, and one may be called
-            // WidgetRepository like something the provider already imports.
-            // Two use statements resolving to the same short name is a fatal
-            // error that takes the whole application down, not just this
-            // context. $migrations avoids it the same way, by holding strings.
             $contents = $this->appendToArray($contents, 'commands', "        \\{$class}::class,");
         }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -90,7 +90,13 @@ final class MakeAggregateCommand extends ScaffoldCommand
         //
         // --factory adds HasFactory to the model after the stub is rendered,
         // so the stubs alone do not know about it.
-        if ($this->refusesCollidingNames('aggregate.*', $this->replacements(), ['Illuminate\Database\Eloquent\Factories\HasFactory'])) {
+        // seederUses is asked for whether or not --factory was passed, for the
+        // same reason every stub is asked whether or not its flag was: the
+        // guard answering differently depending on the flags is a worse thing
+        // to reason about than a refused name nobody should want.
+        if ($this->refusesCollidingNames('aggregate.*', $this->replacements([
+            '{{ seederUses }}' => $this->seederUses(),
+        ]), ['Illuminate\Database\Eloquent\Factories\HasFactory'])) {
             return self::FAILURE;
         }
 
@@ -521,9 +527,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
             $seeder = $this->stub('aggregate.seeder', $this->replacements([
                 // App sorts before Illuminate, so this goes in ahead of the
                 // Seeder import and Pint's ordered_imports has nothing to fix.
-                '{{ seederUses }}' => $this->wants('factory')
-                    ? "use App\\{$this->context}\\{$this->plural}\\Domain\\{$this->aggregate};\n"
-                    : '',
+                '{{ seederUses }}' => $this->wants('factory') ? $this->seederUses() : '',
                 '{{ seederBody }}' => $this->wants('factory')
                     ? "        {$this->aggregate}::factory()->count(10)->create();\n"
                     : "        // Nothing here yet. Generate a factory with --factory, then:\n        // {$this->aggregate}::factory()->count(10)->create();\n",
@@ -725,6 +729,20 @@ final class MakeAggregateCommand extends ScaffoldCommand
      * @param  array<string, string>  $extra
      * @return array<string, string>
      */
+    /**
+     * The import --factory adds to the seeder, ahead of Illuminate's Seeder.
+     *
+     * Written once because the collision guard has to render the stub exactly
+     * as this run will: with the placeholder left in, `{{ seederUses }}use
+     * Illuminate\Database\Seeder;` is one line whose `use` is not at column
+     * zero, and the guard never saw it. `ldd:make:aggregate Billing Seeder
+     * --all` wrote both Seeder imports and exited 0.
+     */
+    private function seederUses(): string
+    {
+        return "use App\\{$this->context}\\{$this->plural}\\Domain\\{$this->aggregate};\n";
+    }
+
     private function replacements(array $extra = []): array
     {
         return array_merge([

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -466,10 +466,17 @@ final class MakeAggregateCommand extends ScaffoldCommand
         foreach ($uses as $class) {
             $imported = $this->withImport($model, $class);
 
-            // stubs/ is meant to be edited, so a stub with no namespace line
-            // is reachable. Say so rather than dying on a TypeError.
+            // Two reasons reach here and the fix differs, so neither may be
+            // guessed at. An aggregate named after something the stub already
+            // imports is the reachable one: `hAs` studlies to `HAs`, whose
+            // factory answers to the same name as Eloquent's HasFactory, and
+            // PHP compares those without case.
             if ($imported === null) {
-                $this->components->error("Could not add [{$class}] to the model: stubs/aggregate.model.stub needs a namespace declaration.");
+                $this->components->error("Could not add [{$class}] to the model.");
+                $this->components->bulletList([
+                    "Rename the aggregate if something the model already imports answers to the same short name as [{$class}].",
+                    'Otherwise stubs/aggregate.model.stub has no namespace declaration; it is meant to be edited, so that is reachable too.',
+                ]);
 
                 return false;
             }

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -68,12 +68,6 @@ final class MakeAggregateCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
-        // Checked before anything is written, and against the stubs rather
-        // than a list kept here, so an edited stub cannot make it stale.
-        if ($this->refusesCollidingName($aggregate, 'aggregate.*', ['Illuminate\Database\Eloquent\Factories\HasFactory'])) {
-            return self::FAILURE;
-        }
-
         $this->context = $context;
         $this->aggregate = $aggregate;
         $this->plural = Str::plural($this->aggregate);
@@ -87,6 +81,16 @@ final class MakeAggregateCommand extends ScaffoldCommand
         if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $this->table) !== 1) {
             $this->components->error("The table name must be a valid identifier, [{$this->table}] is not.");
 
+            return self::FAILURE;
+        }
+
+        // Asked of the stubs as this run would render them, before anything
+        // is written. The names that can collide are the ones interpolated
+        // in, so an unrendered stub has nothing useful to compare.
+        //
+        // --factory adds HasFactory to the model after the stub is rendered,
+        // so the stubs alone do not know about it.
+        if ($this->refusesCollidingNames('aggregate.*', $this->replacements(), ['Illuminate\Database\Eloquent\Factories\HasFactory'])) {
             return self::FAILURE;
         }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -70,12 +70,7 @@ final class MakeAggregateCommand extends ScaffoldCommand
 
         // Checked before anything is written, and against the stubs rather
         // than a list kept here, so an edited stub cannot make it stale.
-        if (($stub = $this->stubImportAnsweringTo($aggregate, 'aggregate.*')) !== null) {
-            $this->components->error("[{$aggregate}] answers to the same name as something {$stub} imports.");
-            $this->components->bulletList([
-                'Two things under one short name in one file is a fatal PHP refuses to compile, so pick another name.',
-            ]);
-
+        if ($this->refusesCollidingName($aggregate, 'aggregate.*', ['Illuminate\Database\Eloquent\Factories\HasFactory'])) {
             return self::FAILURE;
         }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -68,6 +68,17 @@ final class MakeAggregateCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
+        // Checked before anything is written, and against the stubs rather
+        // than a list kept here, so an edited stub cannot make it stale.
+        if (($stub = $this->stubImportAnsweringTo($aggregate, 'aggregate.*')) !== null) {
+            $this->components->error("[{$aggregate}] answers to the same name as something {$stub} imports.");
+            $this->components->bulletList([
+                'Two things under one short name in one file is a fatal PHP refuses to compile, so pick another name.',
+            ]);
+
+            return self::FAILURE;
+        }
+
         $this->context = $context;
         $this->aggregate = $aggregate;
         $this->plural = Str::plural($this->aggregate);

--- a/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
@@ -179,11 +179,12 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
             return true;
         }
 
-        $imported = $this->withImport($contents, $class);
-
-        $updated = $imported === null
-            ? null
-            : $this->appendToList($imported, 'return [', "    {$context}ServiceProvider::class,", '');
+        // Written out in full rather than imported. A context called Billing
+        // wants a BillingServiceProvider, and nothing stops this file already
+        // importing one under that name from somewhere else; two imports
+        // resolving to one short name is a fatal, and in this file of all
+        // files it means nothing boots at all.
+        $updated = $this->appendToList($contents, 'return [', "    \\{$class}::class,", '');
 
         // Appending the short name without its import leaves an unqualified
         // reference, and adding the import without the entry leaves a context

--- a/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
@@ -41,6 +41,20 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
+        // Asked of the stubs as this run would render them, before anything
+        // is written. The names that can collide are the ones interpolated
+        // in, so an unrendered stub has nothing useful to compare.
+        //
+        // The provider stub imports BoundedContextServiceProvider and declares
+        // <Context>ServiceProvider, and this one is loaded from
+        // bootstrap/providers.php: a fatal here takes the application down.
+        if ($this->refusesCollidingNames('bounded-context.provider', [
+            '{{ context }}' => $context,
+            '{{ routes }}' => '',
+        ])) {
+            return self::FAILURE;
+        }
+
         $path = app_path($context);
         $provider = $path."/{$context}ServiceProvider.php";
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeBoundedContextCommand.php
@@ -150,8 +150,7 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
     }
 
     /**
-     * Adds the provider to bootstrap/providers.php, keeping the list sorted
-     * the way the file already is.
+     * Adds the provider to bootstrap/providers.php.
      */
     private function registerProvider(string $context): bool
     {
@@ -159,11 +158,11 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
         $contents = $this->files->get($file);
         $class = "App\\{$context}\\{$context}ServiceProvider";
 
-        // Asked of the array itself. Laravel's own providers.php lists classes
-        // fully qualified and this command adds an import and the short name;
-        // resolved through the file's imports both name the same class, and
-        // neither an import on its own nor a mention in a comment counts.
-
+        // Asked of the array itself, resolved through whatever imports the
+        // file has. Laravel lists these fully qualified, an earlier version of
+        // this command listed them by short name behind an import, and either
+        // way the entry names the same class. An import on its own does not
+        // count as registered, and neither does a mention in a comment.
         $listed = SourceFile::at($file);
 
         if (! $listed->parsed()) {
@@ -186,9 +185,8 @@ final class MakeBoundedContextCommand extends ScaffoldCommand
         // files it means nothing boots at all.
         $updated = $this->appendToList($contents, 'return [', "    \\{$class}::class,", '');
 
-        // Appending the short name without its import leaves an unqualified
-        // reference, and adding the import without the entry leaves a context
-        // nothing ever loads. Both are silent, so neither may report green.
+        // A list this could not find is a context nothing ever loads, and
+        // silently: the provider file sits there looking finished. Say so.
         if ($updated === null) {
             $this->components->twoColumnDetail('bootstrap/providers.php', '<fg=red>could not be updated</>');
             $this->components->warn("Register {$class} in bootstrap/providers.php by hand.");

--- a/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
@@ -42,12 +42,7 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
 
         // Checked before anything is written, and against the stubs rather
         // than a list kept here, so an edited stub cannot make it stale.
-        if (($stub = $this->stubImportAnsweringTo($name, 'event-handler')) !== null) {
-            $this->components->error("[{$name}] answers to the same name as something {$stub} imports.");
-            $this->components->bulletList([
-                'Two things under one short name in one file is a fatal PHP refuses to compile, so pick another name.',
-            ]);
-
+        if ($this->refusesCollidingName($name, 'event-handler', ['Illuminate\Contracts\Queue\ShouldQueue'])) {
             return self::FAILURE;
         }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
@@ -40,6 +40,17 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
+        // Checked before anything is written, and against the stubs rather
+        // than a list kept here, so an edited stub cannot make it stale.
+        if (($stub = $this->stubImportAnsweringTo($name, 'event-handler')) !== null) {
+            $this->components->error("[{$name}] answers to the same name as something {$stub} imports.");
+            $this->components->bulletList([
+                'Two things under one short name in one file is a fatal PHP refuses to compile, so pick another name.',
+            ]);
+
+            return self::FAILURE;
+        }
+
         $event = $this->identifier(
             (string) ($this->option('event') ?: "{$target['aggregate']}Created"),
             'event'

--- a/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
@@ -40,12 +40,6 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
-        // Checked before anything is written, and against the stubs rather
-        // than a list kept here, so an edited stub cannot make it stale.
-        if ($this->refusesCollidingName($name, 'event-handler', ['Illuminate\Contracts\Queue\ShouldQueue'])) {
-            return self::FAILURE;
-        }
-
         $event = $this->identifier(
             (string) ($this->option('event') ?: "{$target['aggregate']}Created"),
             'event'
@@ -61,6 +55,23 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
                 "Add it with: php artisan ldd:make:aggregate {$target['context']} {$target['aggregate']} --events",
             ]);
 
+            return self::FAILURE;
+        }
+
+        // Asked of the stubs as this run would render them, before anything
+        // is written. The names that can collide are the ones interpolated
+        // in, so an unrendered stub has nothing useful to compare.
+        //
+        // After the event is resolved, because the handler's only import is
+        // the event: a handler named InvoiceCreated lands under it. --queued
+        // adds ShouldQueue afterwards, which the stub cannot know about.
+        if ($this->refusesCollidingNames('event-handler', [
+            '{{ context }}' => $target['context'],
+            '{{ plural }}' => $target['plural'],
+            '{{ name }}' => $name,
+            '{{ event }}' => $event,
+            '{{ handlerImplements }}' => '',
+        ], ['Illuminate\Contracts\Queue\ShouldQueue'])) {
             return self::FAILURE;
         }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeEventHandlerCommand.php
@@ -165,11 +165,17 @@ final class MakeEventHandlerCommand extends ScaffoldCommand
         $handlerClass = "App\\{$target['context']}\\{$target['plural']}\\Application\\EventHandlers\\{$name}";
         $eventClass = "App\\{$target['context']}\\{$target['plural']}\\Domain\\Events\\{$event}";
 
-        $updated = $this->withImport($contents, $eventClass);
-        $updated = $updated === null ? null : $this->withImport($updated, $handlerClass);
-        $updated = $updated === null
-            ? null
-            : $this->appendToList($updated, 'array $events = [', "        {$event}::class => {$name}::class,");
+        // Written out in full rather than imported under their short names.
+        // Handler and event names are free text, so either may collide with
+        // something the provider already imports, and two imports resolving to
+        // one short name is a fatal that takes the application down from a
+        // command that just printed green. $commands and $migrations avoid it
+        // the same way.
+        $updated = $this->appendToList(
+            $contents,
+            'array $events = [',
+            "        \\{$eventClass}::class => \\{$handlerClass}::class,"
+        );
 
         if ($updated === null) {
             $this->components->twoColumnDetail($this->relative($provider), '<fg=red>could not be wired</>');

--- a/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
@@ -42,12 +42,7 @@ final class MakeUseCaseCommand extends ScaffoldCommand
 
         // Checked before anything is written, and against the stubs rather
         // than a list kept here, so an edited stub cannot make it stale.
-        if (($stub = $this->stubImportAnsweringTo($name, 'use-case*')) !== null) {
-            $this->components->error("[{$name}] answers to the same name as something {$stub} imports.");
-            $this->components->bulletList([
-                'Two things under one short name in one file is a fatal PHP refuses to compile, so pick another name.',
-            ]);
-
+        if ($this->refusesCollidingName($name, 'use-case*')) {
             return self::FAILURE;
         }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
@@ -40,6 +40,17 @@ final class MakeUseCaseCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
+        // Checked before anything is written, and against the stubs rather
+        // than a list kept here, so an edited stub cannot make it stale.
+        if (($stub = $this->stubImportAnsweringTo($name, 'use-case*')) !== null) {
+            $this->components->error("[{$name}] answers to the same name as something {$stub} imports.");
+            $this->components->bulletList([
+                'Two things under one short name in one file is a fatal PHP refuses to compile, so pick another name.',
+            ]);
+
+            return self::FAILURE;
+        }
+
         $stub = $this->option('publishes') ? 'use-case.publishes' : 'use-case';
 
         // put() reports whether it wrote, and saying "created" over the top of

--- a/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeUseCaseCommand.php
@@ -40,12 +40,21 @@ final class MakeUseCaseCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
-        // Checked before anything is written, and against the stubs rather
-        // than a list kept here, so an edited stub cannot make it stale.
-        if ($this->refusesCollidingName($name, 'use-case*')) {
+        // Asked of the stubs as this run would render them, before anything
+        // is written. The names that can collide are the ones interpolated
+        // in, so an unrendered stub has nothing useful to compare.
+        //
+        // Both use-case stubs import the aggregate and its repository, so a
+        // use case named Invoice lands under App\...\Domain\Invoice.
+        if ($this->refusesCollidingNames('use-case*', [
+            '{{ context }}' => $target['context'],
+            '{{ aggregate }}' => $target['aggregate'],
+            '{{ plural }}' => $target['plural'],
+            '{{ variable }}' => Str::camel($target['aggregate']),
+            '{{ name }}' => $name,
+        ])) {
             return self::FAILURE;
         }
-
         $stub = $this->option('publishes') ? 'use-case.publishes' : 'use-case';
 
         // put() reports whether it wrote, and saying "created" over the top of

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -262,68 +262,60 @@ abstract class ScaffoldCommand extends Command
     }
 
     /**
-     * Refuses, loudly, a generated class whose name is already answered to by
-     * something the file it lands in imports.
+     * Refuses, loudly, a run that would generate a file holding two things
+     * under one short name.
      *
-     * @param  list<string>  $also  imports the command adds after the stub
+     * PHP rejects that at compile time whether the two are two imports or an
+     * import and the class the file declares, and a generated file reaches it
+     * from either side: an aggregate called Model lands under Eloquent's
+     * import, a handler called InvoiceCreated lands under its own event, and
+     * an aggregate called Collection puts Illuminate's Collection next to the
+     * one in its own domain.
      *
-     * Two things under one short name in one file is the same compile-time
-     * fatal whether they are two imports or an import and the class itself,
-     * and the second is the easier one to walk into: `ldd:make:aggregate
-     * Catalog Model` writes `class Model extends Model` under Eloquent's
-     * import, and Model, Request, Response, Event and Collection are all
-     * ordinary things to call an aggregate.
+     * The stubs are rendered and read, rather than their names being listed
+     * here. stubs/ is the one thing in this repository meant to be edited, so
+     * a list would describe it as it was the day it was written, and an
+     * earlier version of this guard compared the bare argument against
+     * unrendered imports: it caught Model, whose stub declares the aggregate
+     * name as written, and waved through Json and Aggregate, whose stubs
+     * declare a name derived from it.
      *
-     * Read from the stubs rather than listed here. stubs/ is meant to be
-     * edited, so a list written out in this file would describe the stubs as
-     * they were the day it was written. Imports holding a placeholder are
-     * skipped: those resolve to the generated classes themselves.
-     *
-     * Every stub the command can render is asked, including the ones a given
-     * run would not reach: refusing an aggregate called Request whether or not
+     * Every stub the command can render is asked, including ones a given run
+     * would not reach. Refusing an aggregate called Request whether or not
      * --web was passed costs a name nobody should want in a Laravel
-     * application, and the alternative is a guard that answers differently
-     * depending on the flags, which is a worse thing to reason about.
+     * application, and a guard that answers differently depending on the flags
+     * is a worse thing to reason about.
+     *
+     * @param  array<string, string>  $replacements  the run's stub substitutions
+     * @param  list<string>  $also  imports the command adds after rendering
      */
-    protected function refusesCollidingName(string $name, string $glob, array $also = []): bool
+    protected function refusesCollidingNames(string $glob, array $replacements, array $also = []): bool
     {
-        // Not every import a generated file ends up with comes from its stub:
-        // --queued adds ShouldQueue to a handler and --factory adds HasFactory
-        // to a model, both after the stub is rendered. A guard reading only
-        // stubs/ would pass a handler called ShouldQueue straight through to
-        // `class ShouldQueue implements ShouldQueue`.
-        foreach ($also as $import) {
-            if ($this->shortNameTaken([$import], $name)) {
-                $this->components->error("[{$name}] answers to the same name as [{$import}], which is imported into what this would generate.");
+        foreach ($this->files->glob(base_path("stubs/{$glob}.stub")) ?: [] as $path) {
+            $rendered = str_replace(array_keys($replacements), array_values($replacements), $this->files->get($path));
+
+            preg_match_all('/^use (.+);$/m', $rendered, $imports);
+            preg_match_all('/^(?:(?:final|abstract|readonly)\s+)*(?:class|interface|trait|enum)\s+(\w+)/m', $rendered, $declared);
+
+            // A migration declares an anonymous class, and the route stubs
+            // declare nothing at all.
+            $names = [...$imports[1], ...$also, ...$declared[1]];
+
+            foreach ($names as $index => $name) {
+                $earlier = array_slice($names, 0, $index);
+
+                if (! $this->shortNameTaken($earlier, $name)) {
+                    continue;
+                }
+
+                $this->components->error('Generating ['.basename($path).'] would put two things under the name ['.class_basename(trim($name)).'].');
                 $this->components->bulletList([
-                    'Two things under one short name in one file is a fatal PHP refuses to compile, so pick another name.',
+                    'PHP refuses to compile a file that does, whether they are two imports or an import and the class itself.',
+                    'Pick another name.',
                 ]);
 
                 return true;
             }
-        }
-
-        foreach ($this->files->glob(base_path("stubs/{$glob}.stub")) ?: [] as $path) {
-            preg_match_all('/^use (.+);$/m', $this->files->get($path), $matches);
-
-            $imports = array_values(array_filter(
-                $matches[1],
-                fn (string $import): bool => ! str_contains($import, '{{')
-            ));
-
-            if (! $this->shortNameTaken($imports, $name)) {
-                continue;
-            }
-
-            // Named here rather than at each caller, which had three copies of
-            // it a moment ago. The stub is the file to go and look at, so
-            // naming the glob instead sends somebody to read all of them.
-            $this->components->error("[{$name}] answers to the same name as something ".basename($path).' imports.');
-            $this->components->bulletList([
-                'Two things under one short name in one file is a fatal PHP refuses to compile, so pick another name.',
-            ]);
-
-            return true;
         }
 
         return false;

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -314,7 +314,26 @@ abstract class ScaffoldCommand extends Command
                     continue;
                 }
 
-                $this->components->error('Generating ['.basename($path).'] would put two things under the name ['.class_basename(trim($name)).'].');
+                $other = '';
+
+                foreach ($earlier as $candidate) {
+                    if ($this->shortNameTaken([$candidate], $name)) {
+                        $other = trim($candidate);
+
+                        break;
+                    }
+                }
+
+                // An import this command adds afterwards lands in one file,
+                // not in every stub the glob matched, so naming the stub the
+                // sweep happened to reach first sends the reader to a file
+                // that was never the problem. Name the two things instead.
+                $injected = in_array($name, $added, true) || in_array($other, $added, true);
+                $short = class_basename(trim($name));
+
+                $this->components->error($injected
+                    ? "This run would put two things under the name [{$short}] in one file: [{$other}] and [".trim($name).'].'
+                    : 'Generating ['.basename($path).'] would put two things under the name ['.$short.'].');
                 $this->components->bulletList([
                     'PHP refuses to compile a file that does, whether they are two imports or an import and the class itself.',
                     'Pick another name.',

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -262,12 +262,52 @@ abstract class ScaffoldCommand extends Command
     }
 
     /**
+     * The stub, if any, that imports something answering to the name a
+     * generated class is about to declare.
+     *
+     * Two things under one short name in one file is the same compile-time
+     * fatal whether they are two imports or an import and the class itself,
+     * and the second is the easier one to walk into: `ldd:make:aggregate
+     * Catalog Model` writes `class Model extends Model` under Eloquent's
+     * import, and Model, Request, Response, Event and Collection are all
+     * ordinary things to call an aggregate.
+     *
+     * Read from the stubs rather than listed here. stubs/ is meant to be
+     * edited, so a list written out in this file would describe the stubs as
+     * they were the day it was written. Imports holding a placeholder are
+     * skipped: those resolve to the generated classes themselves.
+     *
+     * Every stub the command can render is asked, including the ones a given
+     * run would not reach: refusing an aggregate called Request whether or not
+     * --web was passed costs a name nobody should want in a Laravel
+     * application, and the alternative is a guard that answers differently
+     * depending on the flags, which is a worse thing to reason about.
+     */
+    protected function stubImportAnsweringTo(string $name, string $glob): ?string
+    {
+        foreach ($this->files->glob(base_path("stubs/{$glob}.stub")) ?: [] as $path) {
+            preg_match_all('/^use (.+);$/m', $this->files->get($path), $matches);
+
+            $imports = array_values(array_filter(
+                $matches[1],
+                fn (string $import): bool => ! str_contains($import, '{{')
+            ));
+
+            if ($this->shortNameTaken($imports, $name)) {
+                return basename($path);
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Whether one of the existing imports already answers to the short name
      * the given class would introduce.
      *
      * @param  list<string>  $imports  the text of each `use` line, without `use` or the semicolon
      */
-    private function shortNameTaken(array $imports, string $class): bool
+    protected function shortNameTaken(array $imports, string $class): bool
     {
         $shortName = function (string $import): string {
             $import = trim($import);

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -262,6 +262,40 @@ abstract class ScaffoldCommand extends Command
     }
 
     /**
+     * Whether one of the existing imports already answers to the short name
+     * the given class would introduce.
+     *
+     * @param  list<string>  $imports  the text of each `use` line, without `use` or the semicolon
+     */
+    private function shortNameTaken(array $imports, string $class): bool
+    {
+        $shortName = function (string $import): string {
+            $import = trim($import);
+
+            // `use Ours\Widget as TheirWidget;` occupies TheirWidget, not Widget.
+            if (preg_match('/\s+as\s+(\S+)$/i', $import, $alias) === 1) {
+                return $alias[1];
+            }
+
+            return substr((string) strrchr('\\'.$import, '\\'), 1);
+        };
+
+        foreach ($imports as $import) {
+            // Function and constant imports live in their own symbol tables,
+            // so neither can collide with a class name.
+            if (preg_match('/^(function|const)\s/i', trim($import)) === 1) {
+                continue;
+            }
+
+            if ($shortName($import) === $shortName($class)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Inserts an import in the order Pint's ordered_imports fixer expects.
      *
      * Returns null when the import cannot be placed, so the caller reports a
@@ -274,6 +308,20 @@ abstract class ScaffoldCommand extends Command
         }
 
         preg_match_all('/^use (.+);$/m', $contents, $matches);
+
+        // Two imports resolving to one short name is a compile-time fatal, and
+        // it takes down every file that loads this one. The check above
+        // compares whole names, so on its own it is happy to put
+        // Ours\Widget next to Theirs\Widget.
+        //
+        // The refusal belongs here rather than in each caller. It was written
+        // out once before, as a comment on the one append that had already
+        // caused the fatal, and the other five call sites carried on importing
+        // into files whose contents are not ours to predict. An invariant kept
+        // by whoever remembers it is not kept.
+        if ($this->shortNameTaken($matches[1], $class)) {
+            return null;
+        }
 
         $imports = [...$matches[1], $class];
 

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -297,15 +297,27 @@ abstract class ScaffoldCommand extends Command
             preg_match_all('/^use (.+);$/m', $rendered, $imports);
             preg_match_all('/^(?:(?:final|abstract|readonly)\s+)*(?:class|interface|trait|enum)\s+(\w+)/m', $rendered, $declared);
 
+            // Functions and constants have their own symbol tables, so neither
+            // can collide with a class name. Dropped here rather than left to
+            // shortNameTaken, which only skips them on the side it is asked
+            // about: a `use function` line reaching it as the candidate has
+            // its prefix stripped with the namespace, and `money` then reads
+            // as taken by an earlier `use App\...\Money`. The file compiles
+            // and no name the caller could pick would change it.
+            $classes = array_values(array_filter(
+                $imports[1],
+                fn (string $import): bool => preg_match('/^(function|const)\s/i', trim($import)) !== 1
+            ));
+
             // An import the command adds that the stub already carries is the
             // same import, not a collision. Without this, a stub edited to
             // bake in HasFactory would refuse every aggregate name there is,
             // and advise picking another one.
-            $added = array_diff(array_map('trim', $also), array_map('trim', $imports[1]));
+            $added = array_diff(array_map('trim', $also), array_map('trim', $classes));
 
             // A migration declares an anonymous class, and the route stubs
             // declare nothing at all.
-            $names = [...$imports[1], ...$added, ...$declared[1]];
+            $names = [...$classes, ...$added, ...$declared[1]];
 
             foreach ($names as $index => $name) {
                 $earlier = array_slice($names, 0, $index);

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -262,8 +262,10 @@ abstract class ScaffoldCommand extends Command
     }
 
     /**
-     * The stub, if any, that imports something answering to the name a
-     * generated class is about to declare.
+     * Refuses, loudly, a generated class whose name is already answered to by
+     * something the file it lands in imports.
+     *
+     * @param  list<string>  $also  imports the command adds after the stub
      *
      * Two things under one short name in one file is the same compile-time
      * fatal whether they are two imports or an import and the class itself,
@@ -283,8 +285,24 @@ abstract class ScaffoldCommand extends Command
      * application, and the alternative is a guard that answers differently
      * depending on the flags, which is a worse thing to reason about.
      */
-    protected function stubImportAnsweringTo(string $name, string $glob): ?string
+    protected function refusesCollidingName(string $name, string $glob, array $also = []): bool
     {
+        // Not every import a generated file ends up with comes from its stub:
+        // --queued adds ShouldQueue to a handler and --factory adds HasFactory
+        // to a model, both after the stub is rendered. A guard reading only
+        // stubs/ would pass a handler called ShouldQueue straight through to
+        // `class ShouldQueue implements ShouldQueue`.
+        foreach ($also as $import) {
+            if ($this->shortNameTaken([$import], $name)) {
+                $this->components->error("[{$name}] answers to the same name as [{$import}], which is imported into what this would generate.");
+                $this->components->bulletList([
+                    'Two things under one short name in one file is a fatal PHP refuses to compile, so pick another name.',
+                ]);
+
+                return true;
+            }
+        }
+
         foreach ($this->files->glob(base_path("stubs/{$glob}.stub")) ?: [] as $path) {
             preg_match_all('/^use (.+);$/m', $this->files->get($path), $matches);
 
@@ -293,12 +311,22 @@ abstract class ScaffoldCommand extends Command
                 fn (string $import): bool => ! str_contains($import, '{{')
             ));
 
-            if ($this->shortNameTaken($imports, $name)) {
-                return basename($path);
+            if (! $this->shortNameTaken($imports, $name)) {
+                continue;
             }
+
+            // Named here rather than at each caller, which had three copies of
+            // it a moment ago. The stub is the file to go and look at, so
+            // naming the glob instead sends somebody to read all of them.
+            $this->components->error("[{$name}] answers to the same name as something ".basename($path).' imports.');
+            $this->components->bulletList([
+                'Two things under one short name in one file is a fatal PHP refuses to compile, so pick another name.',
+            ]);
+
+            return true;
         }
 
-        return null;
+        return false;
     }
 
     /**

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -297,9 +297,15 @@ abstract class ScaffoldCommand extends Command
             preg_match_all('/^use (.+);$/m', $rendered, $imports);
             preg_match_all('/^(?:(?:final|abstract|readonly)\s+)*(?:class|interface|trait|enum)\s+(\w+)/m', $rendered, $declared);
 
+            // An import the command adds that the stub already carries is the
+            // same import, not a collision. Without this, a stub edited to
+            // bake in HasFactory would refuse every aggregate name there is,
+            // and advise picking another one.
+            $added = array_diff(array_map('trim', $also), array_map('trim', $imports[1]));
+
             // A migration declares an anonymous class, and the route stubs
             // declare nothing at all.
-            $names = [...$imports[1], ...$also, ...$declared[1]];
+            $names = [...$imports[1], ...$added, ...$declared[1]];
 
             foreach ($names as $index => $name) {
                 $earlier = array_slice($names, 0, $index);

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -287,7 +287,11 @@ abstract class ScaffoldCommand extends Command
                 continue;
             }
 
-            if ($shortName($import) === $shortName($class)) {
+            // strcasecmp, not ===. PHP resolves class names case-insensitively,
+            // so `use Ours\HAsFactory;` beside Eloquent's HasFactory is the
+            // same fatal, and Str::studly leaves inner case alone: an aggregate
+            // asked for as `hAs` arrives here as `HAs`.
+            if (strcasecmp($shortName($import), $shortName($class)) === 0) {
                 return true;
             }
         }

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -86,7 +86,11 @@ test('it binds the repository in the context provider', function () {
 test('for every name the stubs import, the command refuses or writes files that compile', function () {
     $imported = collect(File::glob(base_path('stubs/aggregate.*.stub')))
         ->flatMap(function (string $stub): array {
-            preg_match_all('/^use (.+);$/m', File::get($stub), $matches);
+            // Not anchored at column zero alone: aggregate.seeder.stub opens
+            // its import line with a placeholder, and that is exactly the one
+            // name this sweep could not reach. Still not matching an indented
+            // `use`, which inside a class body is a trait, not an import.
+            preg_match_all('/(?:^|\}\})use ([^;\n]+);$/m', File::get($stub), $matches);
 
             return $matches[1];
         })

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -108,6 +108,17 @@ test('every name the aggregate stubs import is refused as an aggregate name', fu
     expect(File::directories(app_path('ScaffoldFixture')))->toBeEmpty();
 });
 
+test('it refuses an aggregate named after an import the command adds itself', function () {
+    // Not every import a generated file ends up with comes from its stub.
+    // --factory adds HasFactory to the model afterwards, so a guard reading
+    // only stubs/ waves `class HasFactory` through, under its own import.
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'HasFactory', '--factory' => true])
+        ->expectsOutputToContain('Illuminate\Database\Eloquent\Factories\HasFactory')
+        ->assertFailed();
+
+    expect(File::directories(app_path('ScaffoldFixture')))->toBeEmpty();
+});
+
 test('the refusal names the stub the collision came from', function () {
     // Naming the wrong file is how somebody spends an afternoon editing a stub
     // that was never the problem.

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -67,9 +67,25 @@ test('it binds the repository in the context provider', function () {
         ->assertSuccessful();
 
     expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
-        ->toContain('use App\ScaffoldFixture\Widgets\Domain\Contracts\WidgetRepository;')
-        ->toContain('use App\ScaffoldFixture\Widgets\Infrastructure\Persistence\EloquentWidgetRepository;')
-        ->toContain('WidgetRepository::class => EloquentWidgetRepository::class,');
+        ->toContain('\App\ScaffoldFixture\Widgets\Domain\Contracts\WidgetRepository::class => \App\ScaffoldFixture\Widgets\Infrastructure\Persistence\EloquentWidgetRepository::class,');
+});
+
+test('it binds a repository whose short name the provider already imports', function () {
+    // Same fatal as the event handler, reached through the binding instead:
+    // an aggregate called Widget wants a WidgetRepository, and nothing stops
+    // the provider already importing one from somewhere else.
+    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+
+    File::put($provider, str_replace(
+        'use ComplexHeart',
+        "use App\Elsewhere\WidgetRepository;\nuse ComplexHeart",
+        File::get($provider)
+    ));
+
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
+        ->assertSuccessful();
+
+    expect(php_parses($provider))->toBeTrue();
 });
 
 test('it registers the migration path only when a migration is generated', function () {
@@ -302,8 +318,8 @@ test('it does not bind twice when the provider was reformatted', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])->assertSuccessful();
 
     File::put($provider, str_replace(
-        '        WidgetRepository::class => EloquentWidgetRepository::class,',
-        '            WidgetRepository::class   => EloquentWidgetRepository::class,',
+        '        \App\ScaffoldFixture\Widgets\Domain\Contracts\WidgetRepository::class => \App\ScaffoldFixture\Widgets\Infrastructure\Persistence\EloquentWidgetRepository::class,',
+        '            \App\ScaffoldFixture\Widgets\Domain\Contracts\WidgetRepository::class   => \App\ScaffoldFixture\Widgets\Infrastructure\Persistence\EloquentWidgetRepository::class,',
         File::get($provider)
     ));
 
@@ -312,7 +328,7 @@ test('it does not bind twice when the provider was reformatted', function () {
 
     // EloquentWidgetRepository::class contains WidgetRepository::class, so
     // count the mapping rather than the bare class reference.
-    expect(substr_count(File::get($provider), '=> EloquentWidgetRepository::class'))->toBe(1);
+    expect(substr_count(File::get($provider), '=> \App\ScaffoldFixture\Widgets\Infrastructure\Persistence\EloquentWidgetRepository::class'))->toBe(1);
 });
 
 test('it refuses to scaffold into the Shared foundation layer', function () {
@@ -358,7 +374,7 @@ test('it wires a provider whose arrays are declared inline', function () {
 
     expect(File::get($provider))
         ->toContain('FooRepository::class => EloquentFooRepository::class,')
-        ->toContain('WidgetRepository::class => EloquentWidgetRepository::class,');
+        ->toContain('\App\ScaffoldFixture\Widgets\Domain\Contracts\WidgetRepository::class => \App\ScaffoldFixture\Widgets\Infrastructure\Persistence\EloquentWidgetRepository::class,');
 });
 
 test('it pluralises the aggregate directory and studlies the class', function () {
@@ -611,7 +627,7 @@ test('it refuses to wire into a provider that does not parse', function () {
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget'])
         ->assertFailed();
 
-    expect(substr_count(File::get($provider), '=> EloquentWidgetRepository::class'))->toBe(1);
+    expect(substr_count(File::get($provider), '=> \App\ScaffoldFixture\Widgets\Infrastructure\Persistence\EloquentWidgetRepository::class'))->toBe(1);
 });
 
 test('it fails when the context provider has nothing to wire', function () {

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -70,6 +70,52 @@ test('it binds the repository in the context provider', function () {
         ->toContain('\App\ScaffoldFixture\Widgets\Domain\Contracts\WidgetRepository::class => \App\ScaffoldFixture\Widgets\Infrastructure\Persistence\EloquentWidgetRepository::class,');
 });
 
+/*
+ * Two things answering to one short name in one file is the same fatal whether
+ * they are two imports or an import and the class itself, and the second is
+ * the easier one to walk into: `ldd:make:aggregate Catalog Model` wrote
+ * `class Model extends Model` under Eloquent's import. Model, Request,
+ * Response, Event and Collection are all ordinary names for an aggregate.
+ *
+ * Derived from the stubs, exactly as the guard is, so this fails the moment
+ * the guard stops reading them. A list written out here would agree with a
+ * list written out in the command and both would drift from stubs/, which is
+ * the one thing in this repository that is meant to be edited.
+ */
+test('every name the aggregate stubs import is refused as an aggregate name', function () {
+    $imported = collect(File::glob(base_path('stubs/aggregate.*.stub')))
+        ->flatMap(function (string $stub): array {
+            preg_match_all('/^use (.+);$/m', File::get($stub), $matches);
+
+            return $matches[1];
+        })
+        // These resolve to the generated classes themselves, not to anything
+        // an aggregate name could collide with.
+        ->reject(fn (string $import): bool => str_contains($import, '{{'))
+        ->map(fn (string $import): string => class_basename($import))
+        ->unique()
+        ->values();
+
+    expect($imported)->not->toBeEmpty();
+
+    foreach ($imported as $name) {
+        $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => $name])
+            ->assertFailed();
+    }
+
+    // Refused before anything is written, so the context still holds only what
+    // ldd:make:bounded-context put there.
+    expect(File::directories(app_path('ScaffoldFixture')))->toBeEmpty();
+});
+
+test('the refusal names the stub the collision came from', function () {
+    // Naming the wrong file is how somebody spends an afternoon editing a stub
+    // that was never the problem.
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Model'])
+        ->expectsOutputToContain('aggregate.model.stub')
+        ->assertFailed();
+});
+
 test('it binds a repository whose short name the provider already imports', function () {
     // Same fatal as the event handler, reached through the binding instead:
     // an aggregate called Widget wants a WidgetRepository, and nothing stops

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 
 /*
@@ -142,9 +143,20 @@ test('it refuses an aggregate named after an import the command adds itself', fu
     // Not every import a generated file ends up with comes from its stub.
     // --factory adds HasFactory to the model afterwards, so a guard reading
     // only stubs/ waves `class HasFactory` through, under its own import.
-    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'HasFactory', '--factory' => true])
-        ->expectsOutputToContain('would put two things under the name')
-        ->assertFailed();
+    // Read back rather than asserted through doesntExpectOutputToContain,
+    // which matches per write call and never sees what the components print.
+    $this->withoutMockingConsoleOutput();
+
+    $exit = $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'HasFactory', '--factory' => true]);
+
+    expect($exit)->toBe(1)
+        // No stub is blamed for it: --factory adds this import to the model,
+        // so the stub the sweep happens to reach first never carries it, and
+        // naming one sends the reader to a file that is not the problem, in
+        // the one directory here meant to be edited.
+        ->and(Artisan::output())
+        ->toContain('under the name [HasFactory]')
+        ->not->toContain('.stub');
 
     expect(File::directories(app_path('ScaffoldFixture')))->toBeEmpty();
 });

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -72,25 +72,24 @@ test('it binds the repository in the context provider', function () {
 
 /*
  * Two things answering to one short name in one file is the same fatal whether
- * they are two imports or an import and the class itself, and the second is
- * the easier one to walk into: `ldd:make:aggregate Catalog Model` wrote
- * `class Model extends Model` under Eloquent's import. Model, Request,
- * Response, Event and Collection are all ordinary names for an aggregate.
+ * they are two imports or an import and the class the file declares, and a
+ * generated file reaches it from either side.
  *
- * Derived from the stubs, exactly as the guard is, so this fails the moment
- * the guard stops reading them. A list written out here would agree with a
- * list written out in the command and both would drift from stubs/, which is
- * the one thing in this repository that is meant to be edited.
+ * What is asserted is the invariant itself, from outside: either the command
+ * refuses, or everything it wrote compiles. An earlier version of this test
+ * asserted that every name a stub imports is refused, which is a different and
+ * wrong claim: an aggregate called Exception generates ExceptionException
+ * under `use Exception`, and Schema appears only in the migration stub, which
+ * declares an anonymous class. Both are fine, and a guard that refused them
+ * would be answering a question nobody asked.
  */
-test('every name the aggregate stubs import is refused as an aggregate name', function () {
+test('for every name the stubs import, the command refuses or writes files that compile', function () {
     $imported = collect(File::glob(base_path('stubs/aggregate.*.stub')))
         ->flatMap(function (string $stub): array {
             preg_match_all('/^use (.+);$/m', File::get($stub), $matches);
 
             return $matches[1];
         })
-        // These resolve to the generated classes themselves, not to anything
-        // an aggregate name could collide with.
         ->reject(fn (string $import): bool => str_contains($import, '{{'))
         ->map(fn (string $import): string => class_basename($import))
         ->unique()
@@ -99,21 +98,48 @@ test('every name the aggregate stubs import is refused as an aggregate name', fu
     expect($imported)->not->toBeEmpty();
 
     foreach ($imported as $name) {
-        $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => $name])
-            ->assertFailed();
-    }
+        $this->artisan('ldd:make:aggregate', [
+            'context' => 'ScaffoldFixture', 'name' => $name, '--all' => true,
+        ])->run();
 
-    // Refused before anything is written, so the context still holds only what
-    // ldd:make:bounded-context put there.
-    expect(File::directories(app_path('ScaffoldFixture')))->toBeEmpty();
+        foreach (File::allFiles(app_path('ScaffoldFixture')) as $file) {
+            expect(php_parses($file->getPathname()))->toBeTrue(
+                "ldd:make:aggregate ScaffoldFixture {$name} --all wrote {$file->getFilename()}, which does not compile."
+            );
+        }
+
+        File::deleteDirectory(app_path('ScaffoldFixture/'.Str::plural($name)));
+    }
 });
+
+/*
+ * Eleven of the thirteen aggregate stubs declare a name derived from the
+ * aggregate rather than the aggregate itself, and the collision follows the
+ * derived name. Comparing the argument alone caught Model, whose stub declares
+ * it as written, and waved these three through: that is the half-fixed shape
+ * this branch exists to end.
+ */
+test('it refuses an aggregate whose derived class name collides', function (string $name, array $flags) {
+    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => $name] + $flags)
+        ->expectsOutputToContain('would put two things under the name')
+        ->assertFailed();
+
+    expect(File::directories(app_path('ScaffoldFixture')))->toBeEmpty();
+})->with([
+    // {{ aggregate }}Resource lands on Illuminate's JsonResource.
+    'Json' => ['Json', ['--api' => true]],
+    // {{ aggregate }}Factory lands on the shared AggregateFactory.
+    'Aggregate' => ['Aggregate', ['--factory' => true]],
+    // {{ aggregate }}Controller lands on the shared InertiaController.
+    'Inertia' => ['Inertia', ['--web' => true]],
+]);
 
 test('it refuses an aggregate named after an import the command adds itself', function () {
     // Not every import a generated file ends up with comes from its stub.
     // --factory adds HasFactory to the model afterwards, so a guard reading
     // only stubs/ waves `class HasFactory` through, under its own import.
     $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'HasFactory', '--factory' => true])
-        ->expectsOutputToContain('Illuminate\Database\Eloquent\Factories\HasFactory')
+        ->expectsOutputToContain('would put two things under the name')
         ->assertFailed();
 
     expect(File::directories(app_path('ScaffoldFixture')))->toBeEmpty();

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -41,20 +41,22 @@ test('it scaffolds the context and registers its provider', function () {
 
     expect(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php'))->toBeFile();
 
-    expect(File::get($this->providers))
-        ->toContain('use App\ScaffoldFixture\ScaffoldFixtureServiceProvider;')
-        ->toContain('ScaffoldFixtureServiceProvider::class,');
+    expect(File::get($this->providers))->toContain('\App\ScaffoldFixture\ScaffoldFixtureServiceProvider::class,');
 });
 
-test('it keeps the provider imports alphabetical', function () {
+test('it registers a provider whose short name the list already imports', function () {
+    // The same fatal as in a context provider, in the one file where it means
+    // nothing boots at all. A context called Billing wants a
+    // BillingServiceProvider, and this file may already import one.
+    File::put($this->providers, str_replace(
+        'use App\Shared',
+        "use App\Elsewhere\ScaffoldFixtureServiceProvider;\nuse App\Shared",
+        File::get($this->providers)
+    ));
+
     $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
 
-    preg_match_all('/^use (.+);$/m', File::get($this->providers), $matches);
-
-    $sorted = $matches[1];
-    sort($sorted);
-
-    expect($matches[1])->toBe($sorted);
+    expect(php_parses($this->providers))->toBeTrue();
 });
 
 test('it creates no layer directories', function () {
@@ -163,7 +165,7 @@ test('a context is not mistaken for one whose name ends with it', function () {
     $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
 
     expect(File::get($this->providers))
-        ->toContain("\n    ScaffoldFixtureServiceProvider::class,")
+        ->toContain("\n    \App\ScaffoldFixture\ScaffoldFixtureServiceProvider::class,")
         ->and(php_parses($this->providers))->toBeTrue();
 });
 

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -14,7 +14,10 @@ beforeEach(function () {
     $this->providers = base_path('bootstrap/providers.php');
     $this->providersBackup = File::get($this->providers);
 
-    foreach (['ScaffoldFixture', 'NestedScaffoldFixture'] as $fixture) {
+    // BoundedContext is only ever created if the collision guard stops
+    // working, and a leaked context joins $contexts in the arch suite, so it is
+    // guarded and torn down like the two this file means to create.
+    foreach (['ScaffoldFixture', 'NestedScaffoldFixture', 'BoundedContext'] as $fixture) {
         expect(app_path($fixture))->not->toBeDirectory(
             "app/{$fixture} already exists; refusing to run so the teardown cannot delete it."
         );
@@ -32,6 +35,7 @@ afterEach(function () {
     if ($this->createdFixture ?? false) {
         File::deleteDirectory(app_path('ScaffoldFixture'));
         File::deleteDirectory(app_path('NestedScaffoldFixture'));
+        File::deleteDirectory(app_path('BoundedContext'));
     }
 });
 
@@ -42,6 +46,19 @@ test('it scaffolds the context and registers its provider', function () {
     expect(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php'))->toBeFile();
 
     expect(File::get($this->providers))->toContain('\App\ScaffoldFixture\ScaffoldFixtureServiceProvider::class,');
+});
+
+test('it refuses a context whose provider name collides with the stub import', function () {
+    // The provider stub imports BoundedContextServiceProvider and declares
+    // <Context>ServiceProvider. This provider is loaded from
+    // bootstrap/providers.php, so a fatal in it takes the application down,
+    // and this command was the one generator of four that never asked.
+    $this->artisan('ldd:make:bounded-context', ['name' => 'BoundedContext'])
+        ->expectsOutputToContain('would put two things under the name')
+        ->assertFailed();
+
+    expect(app_path('BoundedContext'))->not->toBeDirectory()
+        ->and(File::get($this->providers))->not->toContain('BoundedContext');
 });
 
 test('it registers a provider whose short name the list already imports', function () {

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -59,6 +59,20 @@ test('queued makes the handler implement ShouldQueue', function () {
         ->and(php_parses($file))->toBeTrue();
 });
 
+test('it refuses a handler named after the event it handles', function () {
+    // The handler stub's only import is the event, and the event defaults to
+    // <Aggregate>Created, so this is the name a user naturally reaches for.
+    // The refusal has to be asked after the event is resolved: before that,
+    // there is nothing to compare the name against.
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'WidgetCreated',
+    ])
+        ->expectsOutputToContain('would put two things under the name')
+        ->assertFailed();
+
+    expect(app_path('ScaffoldFixture/Widgets/Application/EventHandlers'))->not->toBeDirectory();
+});
+
 test('it refuses a handler named after the queue interface', function () {
     // queueTheHandler adds ShouldQueue after the stub is rendered, so the
     // handler came out as `class ShouldQueue implements ShouldQueue` under its
@@ -66,7 +80,7 @@ test('it refuses a handler named after the queue interface', function () {
     $this->artisan('ldd:make:event-handler', [
         'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'ShouldQueue', '--queued' => true,
     ])
-        ->expectsOutputToContain('Illuminate\Contracts\Queue\ShouldQueue')
+        ->expectsOutputToContain('would put two things under the name')
         ->assertFailed();
 
     expect(app_path('ScaffoldFixture/Widgets/Application/EventHandlers'))->not->toBeDirectory();

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -59,6 +59,19 @@ test('queued makes the handler implement ShouldQueue', function () {
         ->and(php_parses($file))->toBeTrue();
 });
 
+test('it refuses a handler named after the queue interface', function () {
+    // queueTheHandler adds ShouldQueue after the stub is rendered, so the
+    // handler came out as `class ShouldQueue implements ShouldQueue` under its
+    // own import: a fatal, reported as created in green.
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'ShouldQueue', '--queued' => true,
+    ])
+        ->expectsOutputToContain('Illuminate\Contracts\Queue\ShouldQueue')
+        ->assertFailed();
+
+    expect(app_path('ScaffoldFixture/Widgets/Application/EventHandlers'))->not->toBeDirectory();
+});
+
 test('it wires a handler whose short name the provider already imports', function () {
     // Handler and event names are free text, so either can land next to
     // something the provider already imports. Two imports resolving to one

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -42,23 +42,32 @@ test('it creates the handler and declares it in the provider', function () {
     // The declaration is the point: a handler missing from $events is never
     // called and nothing anywhere says so.
     expect(File::get($this->provider))
-        ->toContain('use App\ScaffoldFixture\Widgets\Application\EventHandlers\NotifyAccounting;')
-        ->toContain('use App\ScaffoldFixture\Widgets\Domain\Events\WidgetCreated;')
-        ->toContain('WidgetCreated::class => NotifyAccounting::class,')
+        ->toContain('\App\ScaffoldFixture\Widgets\Domain\Events\WidgetCreated::class => \App\ScaffoldFixture\Widgets\Application\EventHandlers\NotifyAccounting::class,')
         ->and(php_parses($this->provider))->toBeTrue();
 });
 
-test('queued makes the handler implement ShouldQueue', function () {
+test('it wires a handler whose short name the provider already imports', function () {
+    // Handler and event names are free text, so either can land next to
+    // something the provider already imports. Two imports resolving to one
+    // short name is a compile-time fatal, and this provider is loaded from
+    // bootstrap/providers.php: it took down every request and every artisan
+    // call, including the one needed to undo it, from a command that had just
+    // printed `wired` in green.
+    //
+    // Nothing caught it because every other test here generates into a
+    // provider this suite created a moment earlier, where what the command
+    // means to write and what the file already holds cannot disagree.
+    File::put($this->provider, str_replace(
+        'use ComplexHeart',
+        "use App\Elsewhere\NotifyAccounting;\nuse ComplexHeart",
+        File::get($this->provider)
+    ));
+
     $this->artisan('ldd:make:event-handler', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting', '--queued' => true,
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
     ])->assertSuccessful();
 
-    $file = app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
-
-    expect(File::get($file))
-        ->toContain('use Illuminate\Contracts\Queue\ShouldQueue;')
-        ->toContain('final readonly class NotifyAccounting implements ShouldQueue')
-        ->and(php_parses($file))->toBeTrue();
+    expect(php_parses($this->provider))->toBeTrue();
 });
 
 test('it defaults to the Created event and accepts another', function () {
@@ -76,7 +85,7 @@ test('it defaults to the Created event and accepts another', function () {
         'context' => 'ScaffoldFixture', 'aggregate' => 'Gadget', 'name' => 'OnPaid', '--event' => 'GadgetPaid',
     ])->assertSuccessful();
 
-    expect(File::get($this->provider))->toContain('GadgetPaid::class => OnPaid::class,');
+    expect(File::get($this->provider))->toContain('\App\ScaffoldFixture\Gadgets\Domain\Events\GadgetPaid::class => \App\ScaffoldFixture\Gadgets\Application\EventHandlers\OnPaid::class,');
 });
 
 test('it refuses an event the aggregate does not have', function () {
@@ -115,7 +124,7 @@ test('a commented out mapping does not block the command', function () {
         'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
     ])->assertSuccessful();
 
-    expect(File::get($this->provider))->toContain('WidgetCreated::class => NotifyAccounting::class,');
+    expect(File::get($this->provider))->toContain('\App\ScaffoldFixture\Widgets\Domain\Events\WidgetCreated::class => \App\ScaffoldFixture\Widgets\Application\EventHandlers\NotifyAccounting::class,');
 });
 
 test('queued leaves a handler it did not write alone', function () {
@@ -127,7 +136,7 @@ test('queued leaves a handler it did not write alone', function () {
     // run that could not wire it. Importing ShouldQueue into a class that
     // never gains the implements clause is an unused import Pint rejects.
     File::put($this->provider, str_replace(
-        '        WidgetCreated::class => NotifyAccounting::class,'."\n",
+        '        \App\ScaffoldFixture\Widgets\Domain\Events\WidgetCreated::class => \App\ScaffoldFixture\Widgets\Application\EventHandlers\NotifyAccounting::class,'."\n",
         '',
         File::get($this->provider)
     ));
@@ -146,7 +155,7 @@ test('queued leaves a handler it did not write alone', function () {
     // The run above wired the event back, and a second handler for one already
     // mapped is refused before the hint is ever reached.
     File::put($this->provider, str_replace(
-        '        WidgetCreated::class => NotifyAccounting::class,'."\n",
+        '        \App\ScaffoldFixture\Widgets\Domain\Events\WidgetCreated::class => \App\ScaffoldFixture\Widgets\Application\EventHandlers\NotifyAccounting::class,'."\n",
         '',
         File::get($this->provider)
     ));
@@ -163,7 +172,7 @@ test('it does not claim to have created a handler it skipped', function () {
     $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();
 
     File::put($this->provider, str_replace(
-        '        WidgetCreated::class => NotifyAccounting::class,'."\n",
+        '        \App\ScaffoldFixture\Widgets\Domain\Events\WidgetCreated::class => \App\ScaffoldFixture\Widgets\Application\EventHandlers\NotifyAccounting::class,'."\n",
         '',
         File::get($this->provider)
     ));
@@ -182,7 +191,7 @@ test('queued says nothing about a handler that is already queued', function () {
     $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();
 
     File::put($this->provider, str_replace(
-        '        WidgetCreated::class => NotifyAccounting::class,'."\n",
+        '        \App\ScaffoldFixture\Widgets\Domain\Events\WidgetCreated::class => \App\ScaffoldFixture\Widgets\Application\EventHandlers\NotifyAccounting::class,'."\n",
         '',
         File::get($this->provider)
     ));

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 
 /*
@@ -77,11 +78,16 @@ test('it refuses a handler named after the queue interface', function () {
     // queueTheHandler adds ShouldQueue after the stub is rendered, so the
     // handler came out as `class ShouldQueue implements ShouldQueue` under its
     // own import: a fatal, reported as created in green.
-    $this->artisan('ldd:make:event-handler', [
+    $this->withoutMockingConsoleOutput();
+
+    $exit = $this->artisan('ldd:make:event-handler', [
         'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'ShouldQueue', '--queued' => true,
-    ])
-        ->expectsOutputToContain('would put two things under the name')
-        ->assertFailed();
+    ]);
+
+    expect($exit)->toBe(1)
+        ->and(Artisan::output())
+        ->toContain('under the name [ShouldQueue]')
+        ->not->toContain('.stub');
 
     expect(app_path('ScaffoldFixture/Widgets/Application/EventHandlers'))->not->toBeDirectory();
 });

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -46,6 +46,19 @@ test('it creates the handler and declares it in the provider', function () {
         ->and(php_parses($this->provider))->toBeTrue();
 });
 
+test('queued makes the handler implement ShouldQueue', function () {
+    $this->artisan('ldd:make:event-handler', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting', '--queued' => true,
+    ])->assertSuccessful();
+
+    $file = app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
+
+    expect(File::get($file))
+        ->toContain('use Illuminate\Contracts\Queue\ShouldQueue;')
+        ->toContain('final readonly class NotifyAccounting implements ShouldQueue')
+        ->and(php_parses($file))->toBeTrue();
+});
+
 test('it wires a handler whose short name the provider already imports', function () {
     // Handler and event names are free text, so either can land next to
     // something the provider already imports. Two imports resolving to one

--- a/tests/Feature/Shared/MakeUseCaseCommandTest.php
+++ b/tests/Feature/Shared/MakeUseCaseCommandTest.php
@@ -31,6 +31,40 @@ afterEach(function () {
     }
 });
 
+test('a function import in a stub does not take a class name', function () {
+    // Functions and constants have their own symbol tables, so neither can
+    // collide with a class. The skip for them was written but applied only to
+    // the side the comparison was asked about, so a `use function` line
+    // reaching it as the candidate lost its prefix along with its namespace
+    // and read as taken by an earlier Money import. Every use case name was
+    // then refused, over a file PHP compiles without complaint, and no name
+    // the caller could pick would have helped.
+    //
+    // stubs/ is the one directory here meant to be edited, which is the whole
+    // premise of reading the guard's vocabulary out of it.
+    $stub = base_path('stubs/use-case.stub');
+    $original = File::get($stub);
+
+    File::put($stub, str_replace(
+        'use App\{{ context }}\{{ plural }}\Domain\{{ aggregate }};',
+        "use App\Shared\Domain\Money;\nuse function App\Shared\Domain\money;\nuse App\{{ context }}\{{ plural }}\Domain\{{ aggregate }};",
+        $original
+    ));
+
+    try {
+        $this->artisan('ldd:make:use-case', [
+            'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'CreateWidget',
+        ])->assertSuccessful();
+
+        // And the real collision is still caught with that stub in place.
+        $this->artisan('ldd:make:use-case', [
+            'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'Widget',
+        ])->assertFailed();
+    } finally {
+        File::put($stub, $original);
+    }
+});
+
 test('it refuses a use case named after the aggregate it acts on', function (string $name) {
     // Both use-case stubs import the aggregate and its repository, so a use
     // case under either name lands on its own import: two things under one

--- a/tests/Feature/Shared/MakeUseCaseCommandTest.php
+++ b/tests/Feature/Shared/MakeUseCaseCommandTest.php
@@ -31,6 +31,19 @@ afterEach(function () {
     }
 });
 
+test('it refuses a use case named after the aggregate it acts on', function (string $name) {
+    // Both use-case stubs import the aggregate and its repository, so a use
+    // case under either name lands on its own import: two things under one
+    // short name, which PHP refuses to compile.
+    $this->artisan('ldd:make:use-case', [
+        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => $name,
+    ])
+        ->expectsOutputToContain('would put two things under the name')
+        ->assertFailed();
+
+    expect(app_path('ScaffoldFixture/Widgets/Application/'.$name.'.php'))->not->toBeFile();
+})->with(['the aggregate' => 'Widget', 'its repository' => 'WidgetRepository']);
+
 test('it creates the use case in the aggregate application layer', function () {
     $this->artisan('ldd:make:use-case', [
         'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',

--- a/tests/Unit/Shared/WithImportTest.php
+++ b/tests/Unit/Shared/WithImportTest.php
@@ -38,6 +38,11 @@ test('it refuses a class whose short name an import already answers to', functio
 })->with([
     'another namespace' => 'App\Theirs\Widget',
     'an alias' => 'App\Theirs\Gadget as Widget',
+
+    // PHP resolves class names case-insensitively, and Str::studly leaves
+    // inner case alone, so an aggregate asked for as `wIdget` reaches this
+    // guard as `WIdget` and collides with a Widget already imported.
+    'the same name in another case' => 'App\Theirs\WIdget',
 ]);
 
 test('it adds the import when the short name is free', function (string $existing) {

--- a/tests/Unit/Shared/WithImportTest.php
+++ b/tests/Unit/Shared/WithImportTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Shared\Infrastructure\Console\Commands\ScaffoldCommand;
+use Illuminate\Filesystem\Filesystem;
+
+/*
+ * withImport() is where the invariant lives, so this is where it is tested.
+ *
+ * It used to dedupe on the whole class name alone, which let it put
+ * Theirs\Widget next to Ours\Widget: two imports answering to one short name,
+ * which PHP rejects at compile time. Five callers passed generated names into
+ * files whose contents are not ours to predict, and the one that had already
+ * caused the fatal was fixed on its own, in place, with the reasoning written
+ * out as a comment beside it. The other four carried on.
+ *
+ * The three commands now write those entries fully qualified and import
+ * nothing, so this guard is what stands between the next caller and the same
+ * afternoon. Its only two remaining callers write into files this run
+ * generated, so nothing else exercises it.
+ */
+function importer(): object
+{
+    return new class(new Filesystem) extends ScaffoldCommand
+    {
+        public function import(string $contents, string $class): ?string
+        {
+            return $this->withImport($contents, $class);
+        }
+    };
+}
+
+test('it refuses a class whose short name an import already answers to', function (string $existing) {
+    $contents = "<?php\n\nnamespace App;\n\nuse {$existing};\n";
+
+    expect(importer()->import($contents, 'App\Ours\Widget'))->toBeNull();
+})->with([
+    'another namespace' => 'App\Theirs\Widget',
+    'an alias' => 'App\Theirs\Gadget as Widget',
+]);
+
+test('it adds the import when the short name is free', function (string $existing) {
+    $contents = "<?php\n\nnamespace App;\n\nuse {$existing};\n";
+
+    expect(importer()->import($contents, 'App\Ours\Widget'))
+        ->toContain('use App\Ours\Widget;');
+})->with([
+    // Aliased away, so Widget is free and Gadget is the name that is taken.
+    'a class aliased to something else' => 'App\Theirs\Widget as Gadget',
+
+    // Functions and constants have their own symbol tables, so neither can
+    // collide with a class name. Refusing on them would block a legal import.
+    'a function of the same name' => 'function App\Theirs\Widget',
+    'a constant of the same name' => 'const App\Theirs\Widget',
+]);
+
+test('the same class asked for twice is left alone rather than refused', function () {
+    // The exact-name check runs first: a caller re-importing what is already
+    // there gets the file back unchanged, not a null it would report as a
+    // failure to wire.
+    $contents = "<?php\n\nnamespace App;\n\nuse App\Ours\Widget;\n";
+
+    expect(importer()->import($contents, 'App\Ours\Widget'))->toBe($contents);
+});

--- a/tests/Unit/Shared/WithImportTest.php
+++ b/tests/Unit/Shared/WithImportTest.php
@@ -8,17 +8,19 @@ use Illuminate\Filesystem\Filesystem;
  *
  * It used to dedupe on the whole class name alone, which let it put
  * Theirs\Widget next to Ours\Widget: two imports answering to one short name,
- * which PHP rejects at compile time. Five callers passed generated names into
- * files whose contents are not ours to predict, and the one that had already
- * caused the fatal was fixed on its own, in place, with the reasoning written
- * out as a comment beside it. The other four carried on.
+ * which PHP rejects at compile time.
  *
- * The three commands now write those entries fully qualified and import
- * nothing, so this guard is what stands between the next caller and the same
- * afternoon. Its only two remaining callers write into files this run
- * generated, so nothing else exercises it.
+ * This had been met once already, on the $commands array, and answered there
+ * by writing the entry out in full and importing nothing. The reasoning went
+ * into a comment beside that one append. Five withImport() calls went on
+ * passing generated names into files whose contents are not ours to predict,
+ * because the answer had been written down as a note rather than as code.
+ *
+ * Those five are gone, so the guard below has no reachable caller left: both
+ * that remain write into files the same run generated. That is the point of
+ * testing it here. It exists for the caller nobody has written yet.
  */
-function importer(): object
+function scaffold_importer(): object
 {
     return new class(new Filesystem) extends ScaffoldCommand
     {
@@ -32,7 +34,7 @@ function importer(): object
 test('it refuses a class whose short name an import already answers to', function (string $existing) {
     $contents = "<?php\n\nnamespace App;\n\nuse {$existing};\n";
 
-    expect(importer()->import($contents, 'App\Ours\Widget'))->toBeNull();
+    expect(scaffold_importer()->import($contents, 'App\Ours\Widget'))->toBeNull();
 })->with([
     'another namespace' => 'App\Theirs\Widget',
     'an alias' => 'App\Theirs\Gadget as Widget',
@@ -41,7 +43,7 @@ test('it refuses a class whose short name an import already answers to', functio
 test('it adds the import when the short name is free', function (string $existing) {
     $contents = "<?php\n\nnamespace App;\n\nuse {$existing};\n";
 
-    expect(importer()->import($contents, 'App\Ours\Widget'))
+    expect(scaffold_importer()->import($contents, 'App\Ours\Widget'))
         ->toContain('use App\Ours\Widget;');
 })->with([
     // Aliased away, so Widget is free and Gadget is the name that is taken.
@@ -59,5 +61,5 @@ test('the same class asked for twice is left alone rather than refused', functio
     // failure to wire.
     $contents = "<?php\n\nnamespace App;\n\nuse App\Ours\Widget;\n";
 
-    expect(importer()->import($contents, 'App\Ours\Widget'))->toBe($contents);
+    expect(scaffold_importer()->import($contents, 'App\Ours\Widget'))->toBe($contents);
 });


### PR DESCRIPTION
The generators wrote a second `use` answering to a short name another import already held, which PHP rejects at compile time. Both files this reaches load from `bootstrap/providers.php`, so it took down every request and every artisan call, including the one needed to undo it, from a command that had just printed `wired` in green. Reproduced on all three paths.

`withImport()` deduped on the whole class name, so five call sites passed generated names into files whose contents are not ours to predict. The two provider arrays and the provider list now write their entries fully qualified and import nothing, which is what `$commands` already did. The refusal now lives in `withImport()` itself rather than in a comment beside one call site, which is why this only got half fixed the first time.

Closes #86