### PR TITLE
fix: #87 #88 #89 #90 four defects in the context this starter ships

### DIFF
--- a/app/IdentityAndAccess/IdentityAndAccessServiceProvider.php
+++ b/app/IdentityAndAccess/IdentityAndAccessServiceProvider.php
@@ -15,6 +15,7 @@ use ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Laravel\Fortify\Fortify;
@@ -34,6 +35,9 @@ class IdentityAndAccessServiceProvider extends BoundedContextServiceProvider
     protected array $events = [
         UserEmailUpdated::class => SendUserEmailVerification::class,
     ];
+
+    /** @var array<int, class-string> */
+    protected array $commands = [];
 
     protected array $migrations = [
         __DIR__.'/Users/Infrastructure/Persistence/Migrations',
@@ -70,6 +74,12 @@ class IdentityAndAccessServiceProvider extends BoundedContextServiceProvider
         // Configure the routes.
         Fortify::loginView(fn () => Inertia::render('Auth/Login', [
             'status' => session('status'),
+            // Login.vue gates the only link to /forgot-password on this, so
+            // without it password reset is reachable by typing the URL and no
+            // other way. Asked of the router rather than of the feature flag:
+            // the link needs the route to exist, which is what enabling the
+            // feature produces.
+            'canResetPassword' => Route::has('password.request'),
         ]));
         Fortify::registerView(fn () => Inertia::render('Auth/Register'));
         Fortify::requestPasswordResetLinkView(fn () => Inertia::render('Auth/ForgotPassword', [

--- a/app/IdentityAndAccess/Users/Infrastructure/Http/Controllers/DeleteUserController.php
+++ b/app/IdentityAndAccess/Users/Infrastructure/Http/Controllers/DeleteUserController.php
@@ -8,6 +8,7 @@ use ComplexHeart\Domain\Contracts\Events\EventBus;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Laravel\Fortify\Actions\ConfirmPassword;
 use Symfony\Component\HttpFoundation\Response;
@@ -29,13 +30,19 @@ class DeleteUserController extends Controller
         $this->confirmation = $confirmation;
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function destroy(Request $request, StatefulGuard $guard): Response
     {
         $confirmation = $this->confirmation;
 
+        // Keyed 'password', which is what DeleteUserForm.vue binds. Under any
+        // other key the modal stays open saying nothing at all, on the most
+        // destructive thing a user can do to their own account.
         if (! $confirmation($guard, $request->user(), $request->password)) {
-            return back(303)->withErrors([
-                'Invalid Password' => __('The password is incorrect.'),
+            throw ValidationException::withMessages([
+                'password' => __('The password is incorrect.'),
             ]);
         }
 

--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -362,7 +362,14 @@ final class MakeAggregateCommand extends ScaffoldCommand
             'api' => [
                 'controller' => "App\\{$this->context}\\{$this->plural}\\Infrastructure\\Http\\Controllers\\API\\{$this->aggregate}Controller",
                 'lines' => [
-                    "Route::prefix('api')->group(function () {",
+                    // Guarded, unlike the web snippet above. bootRoutes()
+                    // applies the api middleware group, which in Laravel is
+                    // SubstituteBindings and nothing else, so a pasted route
+                    // answers with no token. A web show page is often meant to
+                    // be public; an api one reached by id is not, and both the
+                    // stub this file was generated from and the context shipped
+                    // here guard it.
+                    "Route::prefix('api')->middleware('auth:sanctum')->group(function () {",
                     '    '.$route("api.{$slug}.show"),
                     '});',
                     "// the {$this->aggregate}Controller here is the one under Http\\Controllers\\API",

--- a/app/Shared/SharedServiceProvider.php
+++ b/app/Shared/SharedServiceProvider.php
@@ -30,6 +30,9 @@ class SharedServiceProvider extends BoundedContextServiceProvider
         EventBus::class => IlluminateEventBus::class,
     ];
 
+    /** @var array<class-string, class-string> */
+    protected array $events = [];
+
     protected array $migrations = [
         __DIR__.'/Infrastructure/Persistence/Migrations',
     ];

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -198,6 +198,37 @@ arch('service providers extend the bounded context base provider')
     ->toExtend('ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider');
 
 /*
+ * Every provider declares the same wiring arrays the stub does. A provider
+ * missing one does not fail loudly at boot: the generator finds no array to
+ * append to, throws away the binding and the migration path it had already
+ * built, and the aggregate ships with its repository unbound. Both providers
+ * here were missing a different one.
+ *
+ * Read from the stub so the two cannot drift, and $routes is left out of it
+ * because the stub emits that one conditionally.
+ */
+test('every service provider declares the wiring arrays the stub does', function () use ($contexts, $appPath) {
+    preg_match_all(
+        '/^\s*(?:public|protected)\s+array\s+\$(\w+)/m',
+        (string) file_get_contents(dirname($appPath).'/stubs/bounded-context.provider.stub'),
+        $matches
+    );
+
+    expect($matches[1])->not->toBeEmpty();
+
+    foreach ($contexts as $context) {
+        $source = (string) file_get_contents("{$appPath}/{$context}/{$context}ServiceProvider.php");
+
+        foreach ($matches[1] as $property) {
+            expect($source)->toMatch(
+                '/(?:public|protected)\s+array\s+\$'.$property.'\s*=/',
+                "{$context}ServiceProvider does not declare \${$property}."
+            );
+        }
+    }
+});
+
+/*
 |--------------------------------------------------------------------------
 | Code Quality
 |--------------------------------------------------------------------------

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -217,7 +217,15 @@ test('every service provider declares the wiring arrays the stub does', function
     expect($matches[1])->not->toBeEmpty();
 
     foreach ($contexts as $context) {
-        $source = (string) file_get_contents("{$appPath}/{$context}/{$context}ServiceProvider.php");
+        $provider = "{$appPath}/{$context}/{$context}ServiceProvider.php";
+
+        // Asked before reading it. A directory under app/ with no provider is
+        // reachable, a leaked test fixture being the usual way, and reading
+        // one that is not there yields an empty string that then reports every
+        // property as undeclared: the wrong problem, named confidently.
+        expect(is_file($provider))->toBeTrue("app/{$context} has no {$context}ServiceProvider.");
+
+        $source = (string) file_get_contents($provider);
 
         foreach ($matches[1] as $property) {
             expect($source)->toMatch(

--- a/tests/Feature/IdentityAndAccess/DeleteAccountTest.php
+++ b/tests/Feature/IdentityAndAccess/DeleteAccountTest.php
@@ -15,9 +15,16 @@ test('user accounts can be deleted', function () {
 test('correct password must be provided before account can be deleted', function () {
     $this->actingAs($user = User::factory()->create());
 
-    $this->delete('/user', [
+    $response = $this->delete('/user', [
         'password' => 'wrong-password',
     ]);
 
     expect($user->fresh())->not->toBeNull();
+
+    // Under any other key the modal stays open saying nothing at all:
+    // DeleteUserForm.vue binds form.errors.password and nothing else, and the
+    // alert component reads only flashed alerts. This test asserted the
+    // account survived and nothing about the user being told why, so an error
+    // bag keyed 'Invalid Password' sat there rendering into a void.
+    $response->assertSessionHasErrors('password');
 });

--- a/tests/Feature/IdentityAndAccess/PasswordResetTest.php
+++ b/tests/Feature/IdentityAndAccess/PasswordResetTest.php
@@ -10,6 +10,13 @@ test('reset password link screen can be rendered', function () {
     $response->assertStatus(200);
 });
 
+test('the login page carries the prop its link to this screen is gated on', function () {
+    // Login.vue renders the only link to /forgot-password behind
+    // v-if="canResetPassword". Nothing supplied it, so the screen above
+    // answered 200 and this test passed while the page had no way to reach it.
+    $this->get('/login')->assertInertia(fn ($page) => $page->where('canResetPassword', true));
+});
+
 test('reset password link can be requested', function () {
     Notification::fake();
 

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -674,7 +674,10 @@ test('it hints a distinct route for the api controller', function () {
         // URI is kept apart by the prefix group, the convention the rest of
         // the application already follows.
         ->expectsOutputToContain("Route::get('/widgets/{id}', [WidgetController::class, 'show'])->name('widgets.show');")
-        ->expectsOutputToContain("Route::prefix('api')->group(function () {")
+        // Guarded. This assertion pinned the guardless form, so every
+        // scaffolded aggregate shipped a public read endpoint and the suite
+        // called it correct.
+        ->expectsOutputToContain("Route::prefix('api')->middleware('auth:sanctum')->group(function () {")
         ->expectsOutputToContain("Route::get('/widgets/{id}', [WidgetController::class, 'show'])->name('api.widgets.show');")
         ->assertSuccessful();
 });


### PR DESCRIPTION
Four defects in the bounded context the starter ships, each reproduced before the fix and verified after.

**#87** The provider stub declares four wiring arrays and each shipped provider was missing a different one, so `ldd:make:aggregate --command` built the repository binding and the migration path, found no `$commands` to append to, and discarded all of it: the aggregate came out with its repository unbound. The arch suite now reads the property names out of the stub and checks every provider against them, so the two cannot drift again.

**#88** The api route snippet the generator prints had no middleware, while the stub it comes from and the shipped `api.php` both guard with `auth:sanctum`, so every scaffolded aggregate offered a public read endpoint. The test pinned the guardless form.

**#89** `Login.vue` gates its only link to `/forgot-password` on `canResetPassword` and nothing supplied it, so password reset was reachable by typing the URL and no other way.

**#90** Deleting an account with the wrong password flashed an error bag under a key no field binds, leaving the modal open with no message on the most destructive action a user has.

Three of the four had a test that passed throughout. Each now fails when its defect is reintroduced.

Closes #87
Closes #88
Closes #89
Closes #90