### PR TITLE
The layering rules reach app/Shared, and the generator tests stop writing into app/

### DIFF
--- a/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/MakeAggregateCommand.php
@@ -90,6 +90,15 @@ final class MakeAggregateCommand extends ScaffoldCommand
             return self::FAILURE;
         }
 
+        if (($onDisk = $this->misspelling($this->context)) !== null) {
+            $this->components->error("The bounded context on disk is [{$onDisk}], not [{$this->context}].");
+            $this->components->bulletList([
+                "Run it again as: {$onDisk}",
+            ]);
+
+            return self::FAILURE;
+        }
+
         // An aggregate needs a context the way a handler needs an aggregate.
         // Creating one from here would be generating upwards, and the context
         // is also the one thing this command never touches again: it only
@@ -98,15 +107,6 @@ final class MakeAggregateCommand extends ScaffoldCommand
             $this->components->error("The bounded context [{$this->context}] does not exist.");
             $this->components->bulletList([
                 "Create it with: php artisan ldd:make:bounded-context {$this->context}",
-            ]);
-
-            return self::FAILURE;
-        }
-
-        if (($onDisk = $this->misspelling($this->context)) !== null) {
-            $this->components->error("The bounded context on disk is [{$onDisk}], not [{$this->context}].");
-            $this->components->bulletList([
-                "Run it again as: {$onDisk}",
             ]);
 
             return self::FAILURE;

--- a/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
+++ b/app/Shared/Infrastructure/Console/Commands/ScaffoldCommand.php
@@ -185,21 +185,25 @@ abstract class ScaffoldCommand extends Command
             return null;
         }
 
+        if (($onDisk = $this->misspelling($context)) !== null) {
+            $this->components->error("The bounded context on disk is [{$onDisk}], not [{$context}].");
+            $this->components->bulletList([
+                "Run it again as: {$onDisk}",
+            ]);
+
+            return null;
+        }
+
+        // Before the existence check, so it fires whatever the filesystem
+        // does about case: on a case-sensitive one the check below would
+        // otherwise say the context does not exist and invite creating a
+        // near-duplicate beside the real one.
         // A directory alone is not a context: it also has to have a provider
         // named after it, which is the file the report tells you to edit.
         if (! $this->files->exists(app_path("{$context}/{$context}ServiceProvider.php"))) {
             $this->components->error("The bounded context [{$context}] does not exist.");
             $this->components->bulletList([
                 "Create it with: php artisan ldd:make:bounded-context {$context}",
-            ]);
-
-            return null;
-        }
-
-        if (($onDisk = $this->misspelling($context)) !== null) {
-            $this->components->error("The bounded context on disk is [{$onDisk}], not [{$context}].");
-            $this->components->bulletList([
-                "Run it again as: {$onDisk}",
             ]);
 
             return null;

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -161,6 +161,37 @@ foreach ($boundedContexts as $context) {
     }
 }
 
+/*
+ * The same layering rule, for the one context the patterns above structurally
+ * cannot reach. Every rule so far matches App\<Context>\<Aggregate>\<Layer>,
+ * three segments, because a bounded context keeps its layers inside each
+ * aggregate. Shared has no aggregates, so its layers sit two segments in and
+ * no pattern ever saw them: a Domain file there could import Infrastructure
+ * and the suite stayed green, while the comment at the top of this file says
+ * the rule has no exceptions.
+ *
+ * app/Shared is the foundation every context builds on, so it is the last
+ * place that should get to skip it.
+ *
+ * Emitted only for the layers that exist, like the loop above: Pest throws on
+ * a pattern that matches nothing, and Shared has no Application layer today.
+ */
+foreach (['Application', 'Infrastructure'] as $outer) {
+    if (! is_dir($appPath.'/Shared/Domain') || ! is_dir($appPath.'/Shared/'.$outer)) {
+        continue;
+    }
+
+    arch('shared domain does not depend on '.strtolower($outer))
+        ->expect('App\Shared\Domain')
+        ->not->toUse('App\Shared\\'.$outer);
+}
+
+if (is_dir($appPath.'/Shared/Application') && is_dir($appPath.'/Shared/Infrastructure')) {
+    arch('shared application does not depend on infrastructure')
+        ->expect('App\Shared\Application')
+        ->not->toUse('App\Shared\Infrastructure');
+}
+
 arch('shared context does not depend on any bounded context')
     ->expect('App\Shared')
     ->not->toUse(array_map(fn (string $c): string => 'App\\'.$c, $boundedContexts));

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -44,14 +44,11 @@ beforeEach(function () {
 });
 
 afterEach(function () {
-
     // Both fixtures are removed here rather than in the test body: an
     // assertion that fails leaves whatever the body had not reached yet, and
     // a leaked context makes every later run of the suite fail too.
     if ($this->createdFixture ?? false) {
         File::deleteDirectory($this->pages);
-        File::deleteDirectory(app_path('ScaffoldFixture'));
-        File::deleteDirectory(app_path('ScaffoldOther'));
     }
 
     // The mis-cased context test writes nothing while the guard holds, but the
@@ -60,6 +57,10 @@ afterEach(function () {
     // run of the suite fails on the leftovers. Removed by the path the command
     // would have used, and only ever this one name.
     File::deleteDirectory(app_path('IdentityAndAccess/Probes'));
+
+    // The whole copy, which is where every fixture this file makes now
+    // lives. Left behind, /tmp collected one per worker per run.
+    File::deleteDirectory(dirname($this->providers));
 });
 
 test('it generates only the core by default', function () {

--- a/tests/Feature/Shared/MakeAggregateCommandTest.php
+++ b/tests/Feature/Shared/MakeAggregateCommandTest.php
@@ -13,8 +13,7 @@ use Illuminate\Support\Str;
  * that happened to collide would otherwise take their context with it.
  */
 beforeEach(function () {
-    $this->providers = base_path('bootstrap/providers.php');
-    $this->providersBackup = File::get($this->providers);
+    $this->providers = scaffold_into_a_copy_of_the_app();
 
     foreach (['ScaffoldFixture', 'ScaffoldOther'] as $fixture) {
         expect(app_path($fixture))->not->toBeDirectory(
@@ -40,11 +39,11 @@ beforeEach(function () {
 
     // Read after the fixture context is created: ldd:make:bounded-context is
     // the one command that registers anything, and it rewrites this file.
+
     $this->providersAfterFixture = File::get($this->providers);
 });
 
 afterEach(function () {
-    File::put($this->providers, $this->providersBackup);
 
     // Both fixtures are removed here rather than in the test body: an
     // assertion that fails leaves whatever the body had not reached yet, and
@@ -635,10 +634,7 @@ test('it refuses a context whose real spelling on disk is different', function (
         ->assertFailed();
 
     expect(app_path('IdentityAndAccess/Probes'))->not->toBeDirectory();
-})->skip(
-    ! is_dir(dirname(__DIR__, 3).'/app/identityandaccess'),
-    'the filesystem is case-sensitive, so the name cannot collide'
-);
+});
 
 test('it refuses to put a second aggregate root in one directory', function () {
     // Str::plural leaves a plural alone, so this resolves to the Widgets
@@ -664,10 +660,7 @@ test('a mis-cased aggregate is told the spelling, not blamed for a table collisi
     ])
         ->expectsOutputToContain('The aggregate directory on disk is [APITokens]')
         ->assertFailed();
-})->skip(
-    ! is_dir(dirname(__DIR__, 3).'/app/IdentityAndAccess/apitokens'),
-    'the filesystem is case-sensitive, so the name cannot collide'
-);
+});
 
 test('it refuses a table database/migrations already creates', function () {
     // migrate always merges database_path('migrations') with whatever the

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -26,15 +26,13 @@ beforeEach(function () {
 });
 
 afterEach(function () {
-
     // Removed here rather than in the test body: an assertion that fails
     // leaves whatever the body had not reached yet, and a leaked context
     // makes every later run of the suite fail too.
-    if ($this->createdFixture ?? false) {
-        File::deleteDirectory(app_path('ContextFixture'));
-        File::deleteDirectory(app_path('NestedContextFixture'));
-        File::deleteDirectory(app_path('BoundedContext'));
-    }
+
+    // The whole copy, which is where every fixture this file makes now
+    // lives. Left behind, /tmp collected one per worker per run.
+    File::deleteDirectory(dirname($this->providers));
 });
 
 test('it scaffolds the context and registers its provider', function () {

--- a/tests/Feature/Shared/MakeBoundedContextCommandTest.php
+++ b/tests/Feature/Shared/MakeBoundedContextCommandTest.php
@@ -11,13 +11,12 @@ use Illuminate\Support\Facades\File;
  * name that happened to collide would otherwise be destroyed.
  */
 beforeEach(function () {
-    $this->providers = base_path('bootstrap/providers.php');
-    $this->providersBackup = File::get($this->providers);
+    $this->providers = scaffold_into_a_copy_of_the_app();
 
     // BoundedContext is only ever created if the guard on that name stops
     // working, and a leaked context joins $contexts in the arch suite, so it is
     // guarded and torn down like the two this file means to create.
-    foreach (['ScaffoldFixture', 'NestedScaffoldFixture', 'BoundedContext'] as $fixture) {
+    foreach (['ContextFixture', 'NestedContextFixture', 'BoundedContext'] as $fixture) {
         expect(app_path($fixture))->not->toBeDirectory(
             "app/{$fixture} already exists; refusing to run so the teardown cannot delete it."
         );
@@ -27,29 +26,28 @@ beforeEach(function () {
 });
 
 afterEach(function () {
-    File::put($this->providers, $this->providersBackup);
 
     // Removed here rather than in the test body: an assertion that fails
     // leaves whatever the body had not reached yet, and a leaked context
     // makes every later run of the suite fail too.
     if ($this->createdFixture ?? false) {
-        File::deleteDirectory(app_path('ScaffoldFixture'));
-        File::deleteDirectory(app_path('NestedScaffoldFixture'));
+        File::deleteDirectory(app_path('ContextFixture'));
+        File::deleteDirectory(app_path('NestedContextFixture'));
         File::deleteDirectory(app_path('BoundedContext'));
     }
 });
 
 test('it scaffolds the context and registers its provider', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])
         ->assertSuccessful();
 
-    expect(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php'))->toBeFile();
+    expect(app_path('ContextFixture/ContextFixtureServiceProvider.php'))->toBeFile();
 
     // Registered through Laravel's own helper, the one make:provider uses.
     // It writes every entry fully qualified with no import, which is why this
     // is the one place these commands still edit a file they did not create.
     expect(File::get($this->providers))
-        ->toContain('App\ScaffoldFixture\ScaffoldFixtureServiceProvider::class,')
+        ->toContain('App\ContextFixture\ContextFixtureServiceProvider::class,')
         ->and(php_parses($this->providers))->toBeTrue();
 });
 
@@ -112,29 +110,24 @@ test('it refuses a context whose real spelling on disk is different', function (
         ->assertFailed();
 
     expect(File::get($this->providers))->not->toContain('Identityandaccess');
-})->skip(
-    // Evaluated at collection time, before the application boots, so no
-    // base_path() here. A case-sensitive filesystem cannot reach this state.
-    ! is_dir(dirname(__DIR__, 3).'/app/identityandaccess'),
-    'the filesystem is case-sensitive, so the name cannot collide'
-);
+});
 
 test('it creates no layer directories', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])->assertSuccessful();
 
-    expect(app_path('ScaffoldFixture/Domain'))->not->toBeDirectory()
-        ->and(app_path('ScaffoldFixture/Application'))->not->toBeDirectory()
-        ->and(app_path('ScaffoldFixture/Infrastructure'))->not->toBeDirectory();
+    expect(app_path('ContextFixture/Domain'))->not->toBeDirectory()
+        ->and(app_path('ContextFixture/Application'))->not->toBeDirectory()
+        ->and(app_path('ContextFixture/Infrastructure'))->not->toBeDirectory();
 });
 
 test('route files are opt in', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])->assertSuccessful();
 
-    expect(app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes/web.php'))->not->toBeFile();
+    expect(app_path('ContextFixture/Shared/Infrastructure/Http/Routes/web.php'))->not->toBeFile();
 
     // The convention is documented as a comment, never as a live property
     // pointing at a file that does not exist.
-    expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
+    expect(File::get(app_path('ContextFixture/ContextFixtureServiceProvider.php')))
         ->toContain('// protected array $routes')
         ->not->toMatch('/^\s+protected array \$routes/m');
 });
@@ -143,22 +136,22 @@ test('it declares the route files it generates', function () {
     // A context comes out fully wired, which is what earns every later
     // command the right to wire nothing: the provider is written in the same
     // run, from the same options, so it already declares them.
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true, '--api' => true])
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture', '--web' => true, '--api' => true])
         ->doesntExpectOutputToContain('Register the route files')
         ->assertSuccessful();
 
-    expect(app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes/web.php'))->toBeFile()
-        ->and(app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes/api.php'))->toBeFile();
+    expect(app_path('ContextFixture/Shared/Infrastructure/Http/Routes/web.php'))->toBeFile()
+        ->and(app_path('ContextFixture/Shared/Infrastructure/Http/Routes/api.php'))->toBeFile();
 
-    expect(File::get(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php')))
+    expect(File::get(app_path('ContextFixture/ContextFixtureServiceProvider.php')))
         ->toContain("'web' => [__DIR__.'/Shared/Infrastructure/Http/Routes/web.php']")
         ->toContain("'api' => [__DIR__.'/Shared/Infrastructure/Http/Routes/api.php']");
 });
 
 test('re-running never rewrites the provider', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])->assertSuccessful();
 
-    $provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+    $provider = app_path('ContextFixture/ContextFixtureServiceProvider.php');
 
     File::put($provider, str_replace(
         'public array $bindings = [];',
@@ -171,24 +164,24 @@ test('re-running never rewrites the provider', function () {
     // Asking for route files on a context already in use is the natural way
     // to run this twice; rewriting the provider from the stub would drop
     // every binding and migration path it has accumulated.
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true])
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture', '--web' => true])
         ->assertSuccessful();
 
     expect(File::get($provider))->toBe($before);
 });
 
 test('re-running creates the missing route file and says how to declare it', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])->assertSuccessful();
 
     // The file alone is never loaded: the provider has to declare it, and
     // the provider written by an earlier run is one this run will not touch.
     // The only symptom of getting this wrong is a 404.
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true])
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture', '--web' => true])
         ->expectsOutputToContain('in $routes')
         ->expectsOutputToContain("'web' => [__DIR__.'/Shared/Infrastructure/Http/Routes/web.php'],")
         ->assertSuccessful();
 
-    expect(app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes/web.php'))->toBeFile();
+    expect(app_path('ContextFixture/Shared/Infrastructure/Http/Routes/web.php'))->toBeFile();
 });
 
 test('it asks for the $routes entry even when it wrote nothing at all', function () {
@@ -199,13 +192,13 @@ test('it asks for the $routes entry even when it wrote nothing at all', function
     // stub ships instructs, and then running this to have the tool sort it
     // out. Undeclared, bootRoutes() never loads it and every route in it 404s,
     // over a run that printed green.
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])->assertSuccessful();
 
-    $file = app_path('ScaffoldFixture/Shared/Infrastructure/Http/Routes/web.php');
+    $file = app_path('ContextFixture/Shared/Infrastructure/Http/Routes/web.php');
     File::ensureDirectoryExists(dirname($file));
     File::put($file, "<?php\n");
 
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture', '--web' => true])
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture', '--web' => true])
         ->expectsOutputToContain('exists, skipped')
         ->expectsOutputToContain('in $routes')
         ->expectsOutputToContain("'web' => [__DIR__.'/Shared/Infrastructure/Http/Routes/web.php'],")
@@ -218,59 +211,64 @@ test('it asks for the $routes entry even when it wrote nothing at all', function
 });
 
 test('it says nothing about routes when no route file was asked for', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])->assertSuccessful();
 
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])
         ->expectsOutputToContain('exists, skipped')
         ->doesntExpectOutputToContain('in $routes')
         ->assertSuccessful();
 });
 
 test('it normalises the context name', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'scaffold_fixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'context_fixture'])->assertSuccessful();
 
-    expect(app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php'))->toBeFile();
+    expect(app_path('ContextFixture/ContextFixtureServiceProvider.php'))->toBeFile();
 });
 
 test('it registers the provider however the list is written', function () {
     File::put($this->providers, "<?php\n\nreturn [App\Shared\SharedServiceProvider::class];\n");
 
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])->assertSuccessful();
 
-    expect(File::get($this->providers))->toContain('ScaffoldFixtureServiceProvider::class,')
+    expect(File::get($this->providers))->toContain('ContextFixtureServiceProvider::class,')
         ->and(php_parses($this->providers))->toBeTrue();
 });
 
 test('it fails loudly when there is no provider list to register in', function () {
+    // The one test that removes the file rather than adding to it, so it is
+    // also the one that keeps a copy: everything else in the suite boots
+    // through it, and the teardown only ever takes entries out.
+    $original = File::get($this->providers);
+
     File::delete($this->providers);
 
-    // Reporting success here leaves a context whose bindings, migrations and
-    // routes are never loaded.
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])
-        ->expectsOutputToContain('by hand')
-        ->assertFailed();
-})->after(function () {
-    // Restored here as well: the afterEach above writes the backup, but a
-    // deleted file has to exist again before anything else in the suite boots.
-    File::put(base_path('bootstrap/providers.php'), test()->providersBackup);
+    try {
+        // Reporting success here leaves a context whose bindings, migrations
+        // and routes are never loaded.
+        $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])
+            ->expectsOutputToContain('by hand')
+            ->assertFailed();
+    } finally {
+        File::put($this->providers, $original);
+    }
 });
 
 test('a context is not mistaken for one whose name ends with it', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'NestedScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'NestedContextFixture'])->assertSuccessful();
 
-    // NestedScaffoldFixtureServiceProvider::class contains
-    // ScaffoldFixtureServiceProvider::class, so a substring check would call
+    // NestedContextFixtureServiceProvider::class contains
+    // ContextFixtureServiceProvider::class, so a substring check would call
     // this one already registered and never add it.
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])->assertSuccessful();
 
     expect(File::get($this->providers))
-        ->toContain('App\ScaffoldFixture\ScaffoldFixtureServiceProvider::class,')
+        ->toContain('App\ContextFixture\ContextFixtureServiceProvider::class,')
         ->and(php_parses($this->providers))->toBeTrue();
 });
 
 test('registering an already known provider does not duplicate it', function () {
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:bounded-context', ['name' => 'ContextFixture'])->assertSuccessful();
 
-    expect(substr_count(File::get($this->providers), 'ScaffoldFixtureServiceProvider::class'))->toBe(1);
+    expect(substr_count(File::get($this->providers), 'ContextFixtureServiceProvider::class'))->toBe(1);
 });

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -10,11 +10,10 @@ use Illuminate\Support\Facades\File;
  * happened to collide would otherwise take their context with it.
  */
 beforeEach(function () {
-    $this->providers = base_path('bootstrap/providers.php');
-    $this->providersBackup = File::get($this->providers);
+    $this->providers = scaffold_into_a_copy_of_the_app();
 
-    expect(app_path('ScaffoldFixture'))->not->toBeDirectory(
-        'app/ScaffoldFixture already exists; refusing to run so the teardown cannot delete it.'
+    expect(app_path('HandlerFixture'))->not->toBeDirectory(
+        'app/HandlerFixture already exists; refusing to run so the teardown cannot delete it.'
     );
 
     // Set before anything can fail: a fixture half-built by a run that threw
@@ -22,34 +21,33 @@ beforeEach(function () {
     // suite then refuses at the guard above.
     $this->createdFixture = true;
 
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
-    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
+    $this->artisan('ldd:make:bounded-context', ['name' => 'HandlerFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:aggregate', ['context' => 'HandlerFixture', 'name' => 'Widget', '--events' => true])
         ->assertSuccessful();
 
-    $this->provider = app_path('ScaffoldFixture/ScaffoldFixtureServiceProvider.php');
+    $this->provider = app_path('HandlerFixture/HandlerFixtureServiceProvider.php');
 });
 
 afterEach(function () {
-    File::put($this->providers, $this->providersBackup);
 
     if ($this->createdFixture ?? false) {
-        File::deleteDirectory(app_path('ScaffoldFixture'));
+        File::deleteDirectory(app_path('HandlerFixture'));
     }
 });
 
 test('it creates the handler and says how to declare it', function () {
     $this->artisan('ldd:make:event-handler', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
+        'context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
     ])
         // The declaration is the point: a handler missing from $events is
         // never called and nothing anywhere says so. It is printed rather
         // than appended because $events is keyed by the event, and what
         // should happen when the key is taken is not this command's call.
         ->expectsOutputToContain('in $events')
-        ->expectsOutputToContain('\App\ScaffoldFixture\Widgets\Domain\Events\WidgetCreated::class => \App\ScaffoldFixture\Widgets\Application\EventHandlers\NotifyAccounting::class,')
+        ->expectsOutputToContain('\App\HandlerFixture\Widgets\Domain\Events\WidgetCreated::class => \App\HandlerFixture\Widgets\Application\EventHandlers\NotifyAccounting::class,')
         ->assertSuccessful();
 
-    $file = app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
+    $file = app_path('HandlerFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
 
     expect($file)->toBeFile()
         ->and(php_parses($file))->toBeTrue();
@@ -67,7 +65,7 @@ test('the report says it did not read the files, and how a second handler is add
     $this->withoutMockingConsoleOutput();
 
     $this->artisan('ldd:make:event-handler', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
+        'context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
     ]);
 
     expect(Artisan::output())
@@ -76,7 +74,7 @@ test('the report says it did not read the files, and how a second handler is add
         ->toContain('PHP keeps only the last')
         // The form that loses neither handler. bootEvents() listens for every
         // entry when the value is a list.
-        ->toContain('\App\ScaffoldFixture\Widgets\Domain\Events\WidgetCreated::class => [')
+        ->toContain('\App\HandlerFixture\Widgets\Domain\Events\WidgetCreated::class => [')
         ->toContain('// the handler already mapped to it, first');
 });
 
@@ -89,7 +87,7 @@ test('it leaves the provider exactly as it found it', function () {
     $before = File::get($this->provider);
 
     $this->artisan('ldd:make:event-handler', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
+        'context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
     ])->assertSuccessful();
 
     expect(File::get($this->provider))->toBe($before);
@@ -107,14 +105,14 @@ test('a name the provider already imports is still generated and still compiles'
     ));
 
     $this->artisan('ldd:make:event-handler', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
+        'context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting',
     ])->assertSuccessful();
 
     // The handler itself, which is what the name of this test is about.
     // Neither a green exit nor a parseable provider can observe it: handle()
     // returns SUCCESS unconditionally and never opens the provider, so both
     // assertions below held with nothing written at all.
-    $handler = app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
+    $handler = app_path('HandlerFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
 
     expect($handler)->toBeFile()
         ->and(php_parses($handler))->toBeTrue()
@@ -123,10 +121,10 @@ test('a name the provider already imports is still generated and still compiles'
 
 test('queued makes the handler implement ShouldQueue', function () {
     $this->artisan('ldd:make:event-handler', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting', '--queued' => true,
+        'context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting', '--queued' => true,
     ])->assertSuccessful();
 
-    $file = app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
+    $file = app_path('HandlerFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
 
     expect(File::get($file))
         ->toContain('use Illuminate\Contracts\Queue\ShouldQueue;')
@@ -136,19 +134,19 @@ test('queued makes the handler implement ShouldQueue', function () {
 
 test('it defaults to the Created event and accepts another', function () {
     $this->artisan('ldd:make:aggregate', [
-        'context' => 'ScaffoldFixture', 'name' => 'Gadget', '--events' => true,
+        'context' => 'HandlerFixture', 'name' => 'Gadget', '--events' => true,
     ])->assertSuccessful();
 
     File::copy(
-        app_path('ScaffoldFixture/Gadgets/Domain/Events/GadgetCreated.php'),
-        $paid = app_path('ScaffoldFixture/Gadgets/Domain/Events/GadgetPaid.php')
+        app_path('HandlerFixture/Gadgets/Domain/Events/GadgetCreated.php'),
+        $paid = app_path('HandlerFixture/Gadgets/Domain/Events/GadgetPaid.php')
     );
     File::put($paid, str_replace('GadgetCreated', 'GadgetPaid', File::get($paid)));
 
     $this->artisan('ldd:make:event-handler', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Gadget', 'name' => 'OnPaid', '--event' => 'GadgetPaid',
+        'context' => 'HandlerFixture', 'aggregate' => 'Gadget', 'name' => 'OnPaid', '--event' => 'GadgetPaid',
     ])
-        ->expectsOutputToContain('\App\ScaffoldFixture\Gadgets\Domain\Events\GadgetPaid::class => \App\ScaffoldFixture\Gadgets\Application\EventHandlers\OnPaid::class,')
+        ->expectsOutputToContain('\App\HandlerFixture\Gadgets\Domain\Events\GadgetPaid::class => \App\HandlerFixture\Gadgets\Application\EventHandlers\OnPaid::class,')
         ->assertSuccessful();
 });
 
@@ -157,12 +155,12 @@ test('it refuses an event the aggregate does not have', function () {
     // belongs to the aggregate, and the command that owns the aggregate is
     // the one that makes it.
     $this->artisan('ldd:make:event-handler', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'OnPaid', '--event' => 'WidgetPaid',
+        'context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'OnPaid', '--event' => 'WidgetPaid',
     ])
-        ->expectsOutputToContain('ldd:make:aggregate ScaffoldFixture Widget --events')
+        ->expectsOutputToContain('ldd:make:aggregate HandlerFixture Widget --events')
         ->assertFailed();
 
-    expect(app_path('ScaffoldFixture/Widgets/Application/EventHandlers'))->not->toBeDirectory();
+    expect(app_path('HandlerFixture/Widgets/Application/EventHandlers'))->not->toBeDirectory();
 });
 
 test('it refuses a mis-cased event name', function () {
@@ -170,22 +168,19 @@ test('it refuses a mis-cased event name', function () {
     // a run that found the file through a case-insensitive filesystem writes
     // an import that resolves nowhere else.
     $this->artisan('ldd:make:event-handler', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'OnCreated', '--event' => 'widgetcreated',
+        'context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'OnCreated', '--event' => 'widgetcreated',
     ])
         ->expectsOutputToContain('The event on disk is [WidgetCreated]')
         ->assertFailed();
 
-    expect(app_path('ScaffoldFixture/Widgets/Application/EventHandlers/OnCreated.php'))->not->toBeFile();
-})->skip(
-    ! is_dir(dirname(__DIR__, 3).'/app/identityandaccess'),
-    'the filesystem is case-sensitive, so the name cannot collide'
-);
+    expect(app_path('HandlerFixture/Widgets/Application/EventHandlers/OnCreated.php'))->not->toBeFile();
+});
 
 test('it refuses an aggregate that does not exist', function () {
     $this->artisan('ldd:make:event-handler', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Nope', 'name' => 'OnThing',
+        'context' => 'HandlerFixture', 'aggregate' => 'Nope', 'name' => 'OnThing',
     ])
-        ->expectsOutputToContain('ldd:make:aggregate ScaffoldFixture Nope')
+        ->expectsOutputToContain('ldd:make:aggregate HandlerFixture Nope')
         ->assertFailed();
 });
 
@@ -198,7 +193,7 @@ test('it refuses a context that does not exist', function () {
 });
 
 test('it does not claim to have created a handler it skipped', function () {
-    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting'];
+    $args = ['context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting'];
 
     $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();
 
@@ -212,7 +207,7 @@ test('it does not claim to have created a handler it skipped', function () {
 });
 
 test('queued leaves a handler it did not write alone, and says so', function () {
-    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting'];
+    $args = ['context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting'];
 
     $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();
 
@@ -225,12 +220,12 @@ test('queued leaves a handler it did not write alone, and says so', function () 
         ->expectsOutputToContain('already existed and was left as it is')
         ->assertSuccessful();
 
-    expect(File::get(app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php')))
+    expect(File::get(app_path('HandlerFixture/Widgets/Application/EventHandlers/NotifyAccounting.php')))
         ->not->toContain('ShouldQueue');
 });
 
 test('the queued note never asks for an import, and never says the handler is not queued', function () {
-    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting', '--queued' => true];
+    $args = ['context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting', '--queued' => true];
 
     $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();
 
@@ -262,7 +257,7 @@ test('it hedges the mapping for a handler that was already on disk', function ()
     // The handler was written against whatever event it was written against,
     // and nothing here reads its handle() signature. Mapping it to this event
     // compiles and then fails at dispatch, or silently does the wrong thing.
-    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting'];
+    $args = ['context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting'];
 
     $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();
 
@@ -274,11 +269,11 @@ test('it hedges the mapping for a handler that was already on disk', function ()
 });
 
 test('it never overwrites a handler that exists', function () {
-    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting'];
+    $args = ['context' => 'HandlerFixture', 'aggregate' => 'Widget', 'name' => 'NotifyAccounting'];
 
     $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();
 
-    $file = app_path('ScaffoldFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
+    $file = app_path('HandlerFixture/Widgets/Application/EventHandlers/NotifyAccounting.php');
     File::put($file, File::get($file)."\n// hand written\n");
 
     $this->artisan('ldd:make:event-handler', $args)->assertSuccessful();

--- a/tests/Feature/Shared/MakeEventHandlerCommandTest.php
+++ b/tests/Feature/Shared/MakeEventHandlerCommandTest.php
@@ -29,10 +29,9 @@ beforeEach(function () {
 });
 
 afterEach(function () {
-
-    if ($this->createdFixture ?? false) {
-        File::deleteDirectory(app_path('HandlerFixture'));
-    }
+    // The whole copy, which is where every fixture this file makes now
+    // lives. Left behind, /tmp collected one per worker per run.
+    File::deleteDirectory(dirname($this->providers));
 });
 
 test('it creates the handler and says how to declare it', function () {

--- a/tests/Feature/Shared/MakeUseCaseCommandTest.php
+++ b/tests/Feature/Shared/MakeUseCaseCommandTest.php
@@ -27,10 +27,9 @@ beforeEach(function () {
 });
 
 afterEach(function () {
-
-    if ($this->createdFixture ?? false) {
-        File::deleteDirectory(app_path('UseCaseFixture'));
-    }
+    // The whole copy, which is where every fixture this file makes now
+    // lives. Left behind, /tmp collected one per worker per run.
+    File::deleteDirectory(dirname($this->providers));
 });
 
 test('it creates the use case in the aggregate application layer', function () {

--- a/tests/Feature/Shared/MakeUseCaseCommandTest.php
+++ b/tests/Feature/Shared/MakeUseCaseCommandTest.php
@@ -10,11 +10,10 @@ use Illuminate\Support\Facades\File;
  * happened to collide would otherwise take their context with it.
  */
 beforeEach(function () {
-    $this->providers = base_path('bootstrap/providers.php');
-    $this->providersBackup = File::get($this->providers);
+    $this->providers = scaffold_into_a_copy_of_the_app();
 
-    expect(app_path('ScaffoldFixture'))->not->toBeDirectory(
-        'app/ScaffoldFixture already exists; refusing to run so the teardown cannot delete it.'
+    expect(app_path('UseCaseFixture'))->not->toBeDirectory(
+        'app/UseCaseFixture already exists; refusing to run so the teardown cannot delete it.'
     );
 
     // Set before anything can fail: a fixture half-built by a run that threw
@@ -22,29 +21,28 @@ beforeEach(function () {
     // suite then refuses at the guard above.
     $this->createdFixture = true;
 
-    $this->artisan('ldd:make:bounded-context', ['name' => 'ScaffoldFixture'])->assertSuccessful();
-    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Widget', '--events' => true])
+    $this->artisan('ldd:make:bounded-context', ['name' => 'UseCaseFixture'])->assertSuccessful();
+    $this->artisan('ldd:make:aggregate', ['context' => 'UseCaseFixture', 'name' => 'Widget', '--events' => true])
         ->assertSuccessful();
 });
 
 afterEach(function () {
-    File::put($this->providers, $this->providersBackup);
 
     if ($this->createdFixture ?? false) {
-        File::deleteDirectory(app_path('ScaffoldFixture'));
+        File::deleteDirectory(app_path('UseCaseFixture'));
     }
 });
 
 test('it creates the use case in the aggregate application layer', function () {
     $this->artisan('ldd:make:use-case', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
+        'context' => 'UseCaseFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
     ])->assertSuccessful();
 
-    $file = app_path('ScaffoldFixture/Widgets/Application/FindWidget.php');
+    $file = app_path('UseCaseFixture/Widgets/Application/FindWidget.php');
 
     expect($file)->toBeFile()
         ->and(File::get($file))
-        ->toContain('namespace App\ScaffoldFixture\Widgets\Application;')
+        ->toContain('namespace App\UseCaseFixture\Widgets\Application;')
         ->toContain('final readonly class FindWidget')
         // The application layer reaches the domain through the contract, which
         // is what the architecture rules check and what keeps it testable.
@@ -54,10 +52,10 @@ test('it creates the use case in the aggregate application layer', function () {
 
 test('publishes scaffolds the transaction and the publish call', function () {
     $this->artisan('ldd:make:use-case', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'CreateWidget', '--publishes' => true,
+        'context' => 'UseCaseFixture', 'aggregate' => 'Widget', 'name' => 'CreateWidget', '--publishes' => true,
     ])->assertSuccessful();
 
-    $file = app_path('ScaffoldFixture/Widgets/Application/CreateWidget.php');
+    $file = app_path('UseCaseFixture/Widgets/Application/CreateWidget.php');
 
     // An aggregate only records its events. Without this the recorded events
     // pile up on the instance and vanish with it.
@@ -70,7 +68,7 @@ test('publishes scaffolds the transaction and the publish call', function () {
 
 test('it points at publishes when the aggregate records events', function () {
     $this->artisan('ldd:make:use-case', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
+        'context' => 'UseCaseFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
     ])
         ->expectsOutputToContain('Widget records domain events.')
         ->assertSuccessful();
@@ -81,7 +79,7 @@ test('it still points at publishes over a use case that already exists', functio
     // command to run, and running it over a use case already on disk reported
     // "left as it is" and said nothing, while the recorded events still went
     // nowhere. What the domain holds decides this, not what this run wrote.
-    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget'];
+    $args = ['context' => 'UseCaseFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget'];
 
     $this->artisan('ldd:make:use-case', $args)->assertSuccessful();
 
@@ -93,7 +91,7 @@ test('it still points at publishes over a use case that already exists', functio
 
 test('it says nothing about publishing when publishes was asked for', function () {
     $this->artisan('ldd:make:use-case', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'CreateWidget', '--publishes' => true,
+        'context' => 'UseCaseFixture', 'aggregate' => 'Widget', 'name' => 'CreateWidget', '--publishes' => true,
     ])
         ->doesntExpectOutputToContain('records domain events')
         ->assertSuccessful();
@@ -103,7 +101,7 @@ test('publishes over a use case that already exists still says what to do', func
     // The path ldd:make:aggregate --events sends you down. Passing the flag it
     // asks for used to leave you with less than omitting it: put() skips the
     // file, the rendered stub is discarded, and the note was behind the flag.
-    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'CreateWidget'];
+    $args = ['context' => 'UseCaseFixture', 'aggregate' => 'Widget', 'name' => 'CreateWidget'];
 
     $this->artisan('ldd:make:use-case', $args)->assertSuccessful();
 
@@ -122,7 +120,7 @@ test('the publish note names what the constructor has to gain', function () {
     $this->withoutMockingConsoleOutput();
 
     $this->artisan('ldd:make:use-case', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
+        'context' => 'UseCaseFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
     ]);
 
     expect(Artisan::output())
@@ -131,11 +129,11 @@ test('the publish note names what the constructor has to gain', function () {
 });
 
 test('it stays quiet when the aggregate has no events to lose', function () {
-    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Gadget'])
+    $this->artisan('ldd:make:aggregate', ['context' => 'UseCaseFixture', 'name' => 'Gadget'])
         ->assertSuccessful();
 
     $this->artisan('ldd:make:use-case', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Gadget', 'name' => 'FindGadget',
+        'context' => 'UseCaseFixture', 'aggregate' => 'Gadget', 'name' => 'FindGadget',
     ])
         ->doesntExpectOutputToContain('records domain events')
         ->assertSuccessful();
@@ -150,7 +148,7 @@ test('the publish idiom it prints is the one the stub writes', function () {
     $this->withoutMockingConsoleOutput();
 
     $this->artisan('ldd:make:use-case', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
+        'context' => 'UseCaseFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget',
     ]);
 
     expect(Artisan::output())
@@ -188,10 +186,7 @@ test('it refuses an aggregate directory whose real spelling is different', funct
         ->assertFailed();
 
     expect(app_path('IdentityAndAccess/APITokens/Application/IssueToken.php'))->not->toBeFile();
-})->skip(
-    ! is_dir(dirname(__DIR__, 3).'/app/IdentityAndAccess/apitokens'),
-    'the filesystem is case-sensitive, so the name cannot collide'
-)->after(function () {
+})->after(function () {
     File::delete(app_path('IdentityAndAccess/APITokens/Application/IssueToken.php'));
 });
 
@@ -207,10 +202,10 @@ test('publishes is refused on a root that cannot publish', function () {
     // bounded context and because method_exists() autoloads: a name another
     // test has already loaded would answer from the class in memory, not from
     // the file this one just wrote.
-    $this->artisan('ldd:make:aggregate', ['context' => 'ScaffoldFixture', 'name' => 'Gizmo'])
+    $this->artisan('ldd:make:aggregate', ['context' => 'UseCaseFixture', 'name' => 'Gizmo'])
         ->assertSuccessful();
 
-    $model = app_path('ScaffoldFixture/Gizmos/Domain/Gizmo.php');
+    $model = app_path('UseCaseFixture/Gizmos/Domain/Gizmo.php');
 
     File::put($model, str_replace(
         ["use App\Shared\Domain\HasDomainEvents;\n", "    use HasDomainEvents;\n"],
@@ -223,12 +218,12 @@ test('publishes is refused on a root that cannot publish', function () {
     expect(File::get($model))->not->toContain('HasDomainEvents');
 
     $this->artisan('ldd:make:use-case', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Gizmo', 'name' => 'CreateGizmo', '--publishes' => true,
+        'context' => 'UseCaseFixture', 'aggregate' => 'Gizmo', 'name' => 'CreateGizmo', '--publishes' => true,
     ])
         ->expectsOutputToContain('cannot publish domain events')
         ->assertFailed();
 
-    expect(app_path('ScaffoldFixture/Gizmos/Application/CreateGizmo.php'))->not->toBeFile();
+    expect(app_path('UseCaseFixture/Gizmos/Application/CreateGizmo.php'))->not->toBeFile();
 });
 
 test('it refuses the plural of an aggregate that exists', function () {
@@ -238,20 +233,20 @@ test('it refuses the plural of an aggregate that exists', function () {
     // so nothing catches it until the container resolves it. The plural is the
     // natural thing to type: it is the directory name ls shows.
     $this->artisan('ldd:make:use-case', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Widgets', 'name' => 'ArchiveWidget',
+        'context' => 'UseCaseFixture', 'aggregate' => 'Widgets', 'name' => 'ArchiveWidget',
     ])
         ->expectsOutputToContain('The aggregate [Widgets] does not exist')
         ->assertFailed();
 
-    expect(app_path('ScaffoldFixture/Widgets/Application/ArchiveWidget.php'))->not->toBeFile();
+    expect(app_path('UseCaseFixture/Widgets/Application/ArchiveWidget.php'))->not->toBeFile();
 });
 
 test('it refuses an aggregate that does not exist', function () {
     $this->artisan('ldd:make:use-case', [
-        'context' => 'ScaffoldFixture', 'aggregate' => 'Nope', 'name' => 'DoThing',
+        'context' => 'UseCaseFixture', 'aggregate' => 'Nope', 'name' => 'DoThing',
     ])->assertFailed();
 
-    expect(app_path('ScaffoldFixture/Nopes'))->not->toBeDirectory();
+    expect(app_path('UseCaseFixture/Nopes'))->not->toBeDirectory();
 });
 
 test('it refuses a context that does not exist', function () {
@@ -261,7 +256,7 @@ test('it refuses a context that does not exist', function () {
 });
 
 test('it does not claim to have created a file it skipped', function () {
-    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget'];
+    $args = ['context' => 'UseCaseFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget'];
 
     $this->artisan('ldd:make:use-case', $args)->assertSuccessful();
 
@@ -274,11 +269,11 @@ test('it does not claim to have created a file it skipped', function () {
 });
 
 test('it never overwrites a use case that exists', function () {
-    $args = ['context' => 'ScaffoldFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget'];
+    $args = ['context' => 'UseCaseFixture', 'aggregate' => 'Widget', 'name' => 'FindWidget'];
 
     $this->artisan('ldd:make:use-case', $args)->assertSuccessful();
 
-    $file = app_path('ScaffoldFixture/Widgets/Application/FindWidget.php');
+    $file = app_path('UseCaseFixture/Widgets/Application/FindWidget.php');
     File::put($file, File::get($file)."\n// hand written\n");
 
     $this->artisan('ldd:make:use-case', $args)->assertSuccessful();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Composer\Autoload\ClassLoader;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
 /*
@@ -61,4 +63,47 @@ function php_parses(string $path): bool
     exec('php -l '.escapeshellarg($path).' 2>&1', $output, $status);
 
     return $status === 0;
+}
+
+/**
+ * Runs the ldd:make:* commands against a copy of the application, and returns
+ * where bootstrap/providers.php now lives.
+ *
+ * These tests used to generate into the real app/ and rewrite the tracked
+ * bootstrap/providers.php. Two things follow from that, and both are why this
+ * exists: a test run leaves a versioned file modified, and under --parallel the
+ * arch suite is scanning app/ while a generator test is creating and deleting
+ * directories inside it, so it fails on a path that vanished mid-iteration.
+ *
+ * The copy is keyed on the pid, so every worker gets its own, and it is a copy
+ * rather than an empty directory because four tests are about the application
+ * as shipped: the migrations Shared owns, and the APITokens aggregate.
+ *
+ * Registered with composer as a second path for the App\ namespace, so a
+ * generated class still autoloads and class_exists() can tell a missing import
+ * from a present one.
+ */
+function scaffold_into_a_copy_of_the_app(): string
+{
+    $root = sys_get_temp_dir().'/ldd-tests-'.getmypid();
+
+    File::deleteDirectory($root);
+    File::ensureDirectoryExists($root);
+    File::copyDirectory(base_path('app'), $root.'/app');
+    File::copy(base_path('bootstrap/providers.php'), $providers = $root.'/providers.php');
+
+    // Resolved before the path moves, and cached on the container from then
+    // on: getNamespace() matches app_path() against composer.json's psr-4
+    // entry, which a copy outside the project cannot satisfy, and Laravel's
+    // own make:mail and make:job ask for it.
+    app()->getNamespace();
+
+    app()->useAppPath($root.'/app');
+    app()->useBootstrapPath($root);
+
+    /** @var ClassLoader $loader */
+    $loader = require base_path('vendor/autoload.php');
+    $loader->addPsr4('App\\', $root.'/app');
+
+    return $providers;
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -103,7 +103,13 @@ function scaffold_into_a_copy_of_the_app(): string
 
     /** @var ClassLoader $loader */
     $loader = require base_path('vendor/autoload.php');
-    $loader->addPsr4('App\\', $root.'/app');
+
+    // Once per process. The path is the same every time, and addPsr4 appends
+    // without looking, so calling it per test left the App\ prefix holding one
+    // duplicate entry per test for every class lookup to walk.
+    if (! in_array($root.'/app', $loader->getPrefixesPsr4()['App\\'] ?? [], true)) {
+        $loader->addPsr4('App\\', $root.'/app');
+    }
 
     return $providers;
 }


### PR DESCRIPTION
Every layering rule matched three namespace segments, which app/Shared cannot have, so the foundation layer was exempt from rules the file says have no exceptions. Rules added for its own layers.

The ldd:make:* tests now run against a per-process copy of the application instead of the real app/ and the tracked bootstrap/providers.php. That is what broke --parallel: the arch suite scans app/ while a generator test creates and deletes directories inside it. `sail test --parallel` now runs the whole suite across 16 processes and leaves both untouched.

One write still lands in the real tree: resources/templates/tailwindcss/js/Pages/Widgets, which lives under base_path rather than app/. It is guarded, cleaned in teardown, and touched by a single test file, so nothing races on it.

Closes #98, closes #100.